### PR TITLE
Decrease default retries to fail faster

### DIFF
--- a/http/client.go
+++ b/http/client.go
@@ -28,7 +28,7 @@ type Client struct {
 // DefaultClient is a dp-net specific http client with sensible timeouts,
 // exponential backoff, and a contextual dialer.
 var DefaultClient = &Client{
-	MaxRetries: 10,
+	MaxRetries: 3,
 	RetryTime:  20 * time.Millisecond,
 
 	HTTPClient: &http.Client{


### PR DESCRIPTION
### What

The default retries limit was 10 which is very high for a library used
for internal retires. This is basically causing friendly fire DDoS
issues an resulting in a very poor user experience as it takes ages to
fail. Reducing the default means that we should fail faster, but still
allows for a small failure tolerance.

### Who can review

Anyone but me.
