### PR TITLE
Used ContextKey type from go-ns, to prevent having incompatible types

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/ONSdigital/dp-net
 go 1.13
 
 require (
+	github.com/ONSdigital/go-ns v0.0.0-20191104121206-f144c4ec2e58
 	github.com/ONSdigital/log.go v1.0.0
 	github.com/facebookgo/freeport v0.0.0-20150612182905-d4adf43b75b9
 	github.com/justinas/alice v1.2.0

--- a/handlers/mapping.go
+++ b/handlers/mapping.go
@@ -1,6 +1,9 @@
 package handlers
 
-import dphttp "github.com/ONSdigital/dp-net/http"
+import (
+	dphttp "github.com/ONSdigital/dp-net/http"
+	"github.com/ONSdigital/go-ns/common"
+)
 
 // Key - iota enum of possible sets of keys for middleware manipulation
 type Key int
@@ -9,7 +12,7 @@ type Key int
 type KeyMap struct {
 	Header  string
 	Cookie  string
-	Context dphttp.ContextKey
+	Context common.ContextKey
 }
 
 // Possible values for sets of keys
@@ -30,7 +33,7 @@ func (k Key) Cookie() string {
 }
 
 // Context returns the context key
-func (k Key) Context() dphttp.ContextKey {
+func (k Key) Context() common.ContextKey {
 	return KeyMaps[k].Context
 }
 
@@ -39,16 +42,16 @@ var KeyMaps = map[Key]*KeyMap{
 	UserAccess: {
 		Header:  dphttp.FlorenceHeaderKey,
 		Cookie:  dphttp.FlorenceCookieKey,
-		Context: dphttp.FlorenceIdentityKey,
+		Context: common.FlorenceIdentityKey,
 	},
 	Locale: {
 		Header:  dphttp.LocaleHeaderKey,
 		Cookie:  dphttp.LocaleCookieKey,
-		Context: dphttp.ContextKey(dphttp.LocaleHeaderKey),
+		Context: common.ContextKey(dphttp.LocaleHeaderKey),
 	},
 	CollectionID: {
 		Header:  dphttp.CollectionIDHeaderKey,
 		Cookie:  dphttp.CollectionIDCookieKey,
-		Context: dphttp.ContextKey(dphttp.CollectionIDHeaderKey),
+		Context: common.ContextKey(dphttp.CollectionIDHeaderKey),
 	},
 }

--- a/http/identity.go
+++ b/http/identity.go
@@ -6,10 +6,9 @@ import (
 	"net/http"
 	"sync"
 	"time"
-)
 
-// ContextKey is an alias of type string
-type ContextKey string
+	"github.com/ONSdigital/go-ns/common"
+)
 
 // A list of common constants used across dp-net packages
 const (
@@ -26,10 +25,10 @@ const (
 	LegacyUser           = "legacyUser"
 	BearerPrefix         = "Bearer "
 
-	UserIdentityKey     = ContextKey("User-Identity")
-	CallerIdentityKey   = ContextKey("Caller-Identity")
-	RequestIdKey        = ContextKey("request-id")
-	FlorenceIdentityKey = ContextKey("florence-id")
+	UserIdentityKey     = common.ContextKey("User-Identity")
+	CallerIdentityKey   = common.ContextKey("Caller-Identity")
+	RequestIdKey        = common.ContextKey("request-id")
+	FlorenceIdentityKey = common.ContextKey("florence-id")
 )
 
 // CheckRequester is an interface to allow mocking of auth.CheckRequest

--- a/http/identity_test.go
+++ b/http/identity_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	"github.com/ONSdigital/go-ns/common"
 	. "github.com/smartystreets/goconvey/convey"
 )
 
@@ -211,7 +212,7 @@ func TestNewRequestID(t *testing.T) {
 func TestGetRequestId(t *testing.T) {
 	Convey("should return requestID if it exists in the provided context", t, func() {
 		ctx := WithRequestId(context.Background(), "666")
-		So(ctx.Value(ContextKey("request-id")).(string), ShouldEqual, "666")
+		So(ctx.Value(common.ContextKey("request-id")).(string), ShouldEqual, "666")
 	})
 
 	Convey("should return empty value if requestID is not in the provided context", t, func() {
@@ -223,11 +224,11 @@ func TestGetRequestId(t *testing.T) {
 func TestSetRequestId(t *testing.T) {
 	Convey("set request id in empty context", t, func() {
 		ctx := WithRequestId(context.Background(), "123")
-		So(ctx.Value(ContextKey("request-id")), ShouldEqual, "123")
+		So(ctx.Value(common.ContextKey("request-id")), ShouldEqual, "123")
 
 		Convey("overwrite context request id with new value", func() {
 			newCtx := WithRequestId(ctx, "456")
-			So(newCtx.Value(ContextKey("request-id")), ShouldEqual, "456")
+			So(newCtx.Value(common.ContextKey("request-id")), ShouldEqual, "456")
 		})
 	})
 }


### PR DESCRIPTION
### What

Use ContextKey type from go-ns, to prevent incompatible types in code that uses this library and other libraries that use the go-ns common ContextKey type. This is important because Context accepts `interface{}` type, so we would not be able to detect mismatches at compile time.

Although this PR looks like a step back, it is created in order to facilitate the transition from go-ns to dp-net. Once everything uses dp-net (and nothing refers to the go-ns ContextKey type directly), we can move the ContextKey type definition to this library, and everything will be consistent.

### How to review

- Make sure code change make sense. I tried to use this in dp-api-router, and checked that context values created by other libraries are correctly read now.
- Unit tests should pass.

### Who can review

Anyone.