### PR TITLE
Copied DrainBody function from go-ns to dp-net/http

### DIFF
--- a/http/utils.go
+++ b/http/utils.go
@@ -1,0 +1,27 @@
+package http
+
+import (
+	"io"
+	"io/ioutil"
+	"net/http"
+
+	"github.com/ONSdigital/log.go/log"
+)
+
+// DrainBody drains the body of the given of the given HTTP request.
+func DrainBody(r *http.Request) {
+
+	if r.Body == nil {
+		return
+	}
+
+	_, err := io.Copy(ioutil.Discard, r.Body)
+	if err != nil {
+		log.Event(r.Context(), "error draining request body", log.Error(err))
+	}
+
+	err = r.Body.Close()
+	if err != nil {
+		log.Event(r.Context(), "error closing request body", log.Error(err))
+	}
+}

--- a/http/utils_test.go
+++ b/http/utils_test.go
@@ -1,0 +1,65 @@
+package http
+
+import (
+	"bytes"
+	"io"
+	"net/http"
+	"testing"
+
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+func TestDrainBody_WithRequestBody(t *testing.T) {
+
+	Convey("Given a request with a body", t, func() {
+
+		body := bytes.NewBufferString("some body content")
+		r, err := http.NewRequest("GET", "/some/url", body)
+		So(err, ShouldBeNil)
+
+		Convey("When the DrainBody function is called", func() {
+
+			DrainBody(r)
+
+			Convey("Then all bytes have been read from the body", func() {
+				_, err = r.Body.Read(make([]byte, 1))
+				So(err, ShouldEqual, io.EOF)
+			})
+		})
+	})
+}
+
+func TestDrainBody_WithEmptyRequestBody(t *testing.T) {
+
+	Convey("Given a request with an empty body", t, func() {
+
+		body := bytes.NewBuffer(make([]byte, 0))
+
+		r, err := http.NewRequest("GET", "/some/url", body)
+		So(err, ShouldBeNil)
+
+		Convey("When the DrainBody function is called", func() {
+
+			DrainBody(r)
+
+			Convey("Then the expected io.EOF is returned when reading the body", func() {
+				_, err = r.Body.Read(make([]byte, 1))
+				So(err, ShouldEqual, io.EOF)
+			})
+		})
+	})
+}
+
+func TestDrainBody_WithoutRequestBody(t *testing.T) {
+
+	Convey("Given a request without a nil body", t, func() {
+
+		r, err := http.NewRequest("GET", "/some/url", nil)
+		So(err, ShouldBeNil)
+
+		Convey("When the DrainBody function is called, there is no panic", func() {
+
+			DrainBody(r)
+		})
+	})
+}


### PR DESCRIPTION
### What

Moved `DrainBody` function from go-ns to dp-net/http. This function is used by dp-api-router

### How to review

- Make sure code changes make sense (function copied from go-ns/request)
  - Note: this was added to http package - if we added it to request package, we would reintroduce the cyclic dependency with log.go
- Unit tests should pass

### Who can review

Anyone