### PR TITLE
New controller middleware handler

### DIFF
--- a/handlers/handlers.go
+++ b/handlers/handlers.go
@@ -2,10 +2,15 @@ package handlers
 
 import (
 	"context"
-	"net/http"
-
+	"errors"
+	"github.com/ONSdigital/dp-api-clients-go/headers"
+	"github.com/ONSdigital/dp-net/request"
 	"github.com/ONSdigital/log.go/log"
+	"net/http"
 )
+
+// ControllerHandlerFunc is a function type that accepts arguments required for logical flow in handlers Implementation of function should set headers as needed
+type ControllerHandlerFunc func(w http.ResponseWriter, r *http.Request, lang, collectionID, accessToken string)
 
 // CheckHeader is a wrapper which adds a value from the request header (if found) to the request context.
 // This function complies with alice middleware Constructor type: func(http.Handler) -> (http.Handler)
@@ -47,4 +52,47 @@ func DoCheckCookie(h http.Handler, key Key) http.Handler {
 		}
 		h.ServeHTTP(w, req)
 	})
+}
+
+// ControllerHandler is a middleware handler that ensures all required logical arguments are being passed along and then returns a generic http.Handler
+func ControllerHandler(controllerHandlerFunc ControllerHandlerFunc) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		ctx := r.Context()
+		locale := request.GetLocaleCode(r)
+		collectionID := getCollectionIDFromContext(ctx)
+		accessToken := getUserAccessTokenFromContext(ctx, r)
+
+		controllerHandlerFunc(w, r, locale, collectionID, accessToken)
+	}
+}
+
+// getUserAccessTokenFromContext will get the Florence Identity Key aka access token from a context or header
+func getUserAccessTokenFromContext(ctx context.Context, r *http.Request) string {
+	var err error = nil
+	accessToken := ""
+	ok := false
+	if ctx.Value(request.FlorenceIdentityKey) != nil {
+		accessToken, ok = ctx.Value(request.FlorenceIdentityKey).(string)
+		if !ok {
+			log.Event(ctx, "error retrieving user access token", log.WARN, log.Error(errors.New("error casting access token context value to string")))
+		}
+	} else {
+		accessToken, err = headers.GetUserAuthToken(r)
+		if err != nil {
+			log.Event(ctx, "access token not found", log.WARN, log.Error(err))
+		}
+	}
+	return accessToken
+}
+
+// getCollectionIDFromContext will get the Collection ID token from a context
+func getCollectionIDFromContext(ctx context.Context) string {
+	if ctx.Value(request.CollectionIDHeaderKey) != nil {
+		collectionID, ok := ctx.Value(request.CollectionIDHeaderKey).(string)
+		if !ok {
+			log.Event(ctx, "error retrieving collection ID", log.WARN, log.Error(errors.New("error casting collection ID context value to string")))
+		}
+		return collectionID
+	}
+	return ""
 }

--- a/handlers/handlers_test.go
+++ b/handlers/handlers_test.go
@@ -2,6 +2,8 @@ package handlers
 
 import (
 	"context"
+	"fmt"
+	dprequest "github.com/ONSdigital/dp-net/request"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -11,6 +13,7 @@ import (
 
 const testToken = "666"
 const testLocale = "cy"
+const testCollectionID = "foo"
 
 type mockHandler struct {
 	invocations int
@@ -179,6 +182,91 @@ func TestCheckCookieLocale(t *testing.T) {
 				localeCode, ok := mockHandler.ctx.Value(Locale.Context()).(string)
 				So(ok, ShouldBeTrue)
 				So(localeCode, ShouldEqual, testLocale)
+			})
+		})
+	})
+}
+
+func TestControllerHandler(t *testing.T) {
+	Convey("given a controllerHandlerFunc and a context with a collectionID, florence ID and a cookie with a locale", t, func() {
+		request := httptest.NewRequest("GET", "http://localhost:8080", nil)
+		request = request.WithContext(context.WithValue(request.Context(), dprequest.CollectionIDHeaderKey, testCollectionID))
+		request = request.WithContext(context.WithValue(request.Context(), dprequest.FlorenceIdentityKey, testToken))
+		request.AddCookie(&http.Cookie{Name: Locale.Cookie(), Value: testLocale})
+		w := httptest.NewRecorder()
+
+		var controllerHandlerFunc ControllerHandlerFunc = func(w http.ResponseWriter, r *http.Request, lang, collectionID, accessToken string) {
+			r.Header.Set(UserAccess.Header(), accessToken)
+			r.Header.Set(CollectionID.Header(), collectionID)
+			r.Header.Set(Locale.Header(), lang)
+		}
+
+		h := ControllerHandler(controllerHandlerFunc)
+		Convey("when the handler is called", func() {
+			h.ServeHTTP(w, request)
+			Convey("the request context contains a value for the locale code", func() {
+				localeCode := request.Header.Get(Locale.Header())
+				So(localeCode, ShouldEqual, testLocale)
+			})
+			Convey("the request context contains a value for the Collection identity", func() {
+				localeCode := request.Header.Get(CollectionID.Header())
+				So(localeCode, ShouldEqual, testCollectionID)
+			})
+			Convey("the request context contains a value for UserAccess token", func() {
+				localeCode := request.Header.Get(UserAccess.Header())
+				So(localeCode, ShouldEqual, testToken)
+			})
+		})
+	})
+	Convey("given a controllerHandlerFunc and a context with no collection ID or florence ID but with a locale in the subdomain", t, func() {
+		target := fmt.Sprintf("http://%s.localhost:8080", testLocale)
+		request := httptest.NewRequest("GET", target, nil)
+		request.Header.Set(UserAccess.Header(), testToken)
+		request.Header.Set(CollectionID.Header(), testCollectionID)
+		w := httptest.NewRecorder()
+
+		var controllerHandlerFunc ControllerHandlerFunc = func(w http.ResponseWriter, r *http.Request, lang, collectionID, accessToken string) {
+			r.Header.Set(UserAccess.Header(), accessToken)
+			r.Header.Set(CollectionID.Header(), collectionID)
+			r.Header.Set(Locale.Header(), lang)
+		}
+
+		h := ControllerHandler(controllerHandlerFunc)
+		Convey("when the handler is called", func() {
+			h.ServeHTTP(w, request)
+			Convey("the request context contains a value for the locale code", func() {
+				localeCode := request.Header.Get(Locale.Header())
+				So(localeCode, ShouldEqual, testLocale)
+			})
+			Convey("the request context contains an empty string value for the Collection identity", func() {
+				localeCode := request.Header.Get(CollectionID.Header())
+				So(localeCode, ShouldEqual, "")
+			})
+			Convey("the request context contains an empty string value for UserAccess token", func() {
+				localeCode := request.Header.Get(UserAccess.Header())
+				So(localeCode, ShouldEqual, "")
+			})
+		})
+	})
+
+	Convey("given a controllerHandlerFunc with no context, no cookies and no subdomain", t, func() {
+		request := httptest.NewRequest("GET", "http://localhost:8080", nil)
+		w := httptest.NewRecorder()
+
+		var controllerHandlerFunc ControllerHandlerFunc = func(w http.ResponseWriter, r *http.Request, lang, collectionID, accessToken string) {
+			r.Header.Set(UserAccess.Header(), accessToken)
+			r.Header.Set(CollectionID.Header(), collectionID)
+			r.Header.Set(Locale.Header(), lang)
+		}
+
+		h := ControllerHandler(controllerHandlerFunc)
+		Convey("when the handler is called", func() {
+			h.ServeHTTP(w, request)
+
+			testDesc := fmt.Sprintf("the request context contains a value for the default locale code: %s", dprequest.DefaultLang)
+			Convey(testDesc, func() {
+				localeCode := request.Header.Get(Locale.Header())
+				So(localeCode, ShouldEqual, dprequest.DefaultLang)
 			})
 		})
 	})

--- a/handlers/identity.go
+++ b/handlers/identity.go
@@ -23,7 +23,7 @@ func Identity(zebedeeURL string) func(http.Handler) http.Handler {
 // IdentityWithHTTPClient allows a handler to be created that uses the given identity client
 func IdentityWithHTTPClient(cli *clientsidentity.Client) func(http.Handler) http.Handler {
 	// maintain the public interface to ensure backwards compatible and allow the get X token functions to be passed into the handler func.
-	return identityWithHTTPClient(cli, getFlorenceToken, getServiceAuthToken)
+	return identityWithHTTPClient(cli, GetFlorenceToken, getServiceAuthToken)
 }
 
 func identityWithHTTPClient(cli *clientsidentity.Client, getFlorenceToken, getServiceToken getTokenFromReqFunc) func(http.Handler) http.Handler {
@@ -73,7 +73,7 @@ func handleFailedRequest(ctx context.Context, w http.ResponseWriter, r *http.Req
 	w.WriteHeader(status)
 }
 
-func getFlorenceToken(ctx context.Context, req *http.Request) (string, error) {
+func GetFlorenceToken(ctx context.Context, req *http.Request) (string, error) {
 	var florenceToken string
 
 	token, err := headers.GetUserAuthToken(req)

--- a/handlers/identity_test.go
+++ b/handlers/identity_test.go
@@ -520,7 +520,7 @@ func TestGetFlorenceToken(t *testing.T) {
 		req := httptest.NewRequest("GET", "http://localhost:8080", nil)
 		req.Header.Set(dprequest.FlorenceHeaderKey, expectedToken)
 
-		actual, err := getFlorenceToken(nil, req)
+		actual, err := GetFlorenceToken(nil, req)
 
 		So(actual, ShouldEqual, expectedToken)
 		So(err, ShouldBeNil)
@@ -530,7 +530,7 @@ func TestGetFlorenceToken(t *testing.T) {
 		req := httptest.NewRequest("GET", "http://localhost:8080", nil)
 		req.AddCookie(&http.Cookie{Name: dprequest.FlorenceCookieKey, Value: expectedToken})
 
-		actual, err := getFlorenceToken(nil, req)
+		actual, err := GetFlorenceToken(nil, req)
 
 		So(actual, ShouldEqual, expectedToken)
 		So(err, ShouldBeNil)
@@ -539,14 +539,14 @@ func TestGetFlorenceToken(t *testing.T) {
 	Convey("should return empty token if no header or cookie is set", t, func() {
 		req := httptest.NewRequest("GET", "http://localhost:8080", nil)
 
-		actual, err := getFlorenceToken(nil, req)
+		actual, err := GetFlorenceToken(nil, req)
 
 		So(actual, ShouldBeEmpty)
 		So(err, ShouldBeNil)
 	})
 
 	Convey("should return empty token and error if get header returns an error that is not ErrHeaderNotFound", t, func() {
-		actual, err := getFlorenceToken(nil, nil)
+		actual, err := GetFlorenceToken(nil, nil)
 
 		So(actual, ShouldBeEmpty)
 		So(err, ShouldResemble, headers.ErrRequestNil)

--- a/request/collection.go
+++ b/request/collection.go
@@ -1,7 +1,39 @@
 package request
 
+import (
+	"github.com/ONSdigital/dp-api-clients-go/headers"
+	"net/http"
+)
+
 // CollectionID header and cookie keys
 const (
 	CollectionIDHeaderKey = "Collection-Id"
 	CollectionIDCookieKey = "collection"
 )
+
+func GetCollectionID(req *http.Request) (string, error) {
+	var collectionID string
+
+	id, err := headers.GetCollectionID(req)
+	if err == nil {
+		collectionID = id
+	} else if headers.IsErrNotFound(err) {
+		collectionID, err = getCollectionIDFromCookie(req)
+	}
+
+	return collectionID, err
+}
+
+func getCollectionIDFromCookie(req *http.Request) (string, error) {
+	var collectionID string
+	var err error
+
+	c, err := req.Cookie(CollectionIDCookieKey)
+	if err == nil {
+		collectionID = c.Value
+	} else if err == http.ErrNoCookie {
+		err = nil // we don't consider this scenario an error so we set err to nil and return an empty string
+	}
+
+	return collectionID, err
+}

--- a/request/collection_test.go
+++ b/request/collection_test.go
@@ -1,0 +1,74 @@
+package request
+
+import (
+	"github.com/ONSdigital/dp-api-clients-go/headers"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+func TestGetCollectionID(t *testing.T) {
+
+	expectedToken := "foo"
+
+	Convey("should return collectionID from request header", t, func() {
+		req := httptest.NewRequest("GET", "http://localhost:8080", nil)
+		req.Header.Set(CollectionIDHeaderKey, expectedToken)
+
+		actual, err := GetCollectionID(req)
+
+		So(actual, ShouldEqual, expectedToken)
+		So(err, ShouldBeNil)
+	})
+
+	Convey("should return collection id from request cookie", t, func() {
+		req := httptest.NewRequest("GET", "http://localhost:8080", nil)
+		req.AddCookie(&http.Cookie{Name: CollectionIDCookieKey, Value: expectedToken})
+
+		actual, err := GetCollectionID(req)
+
+		So(actual, ShouldEqual, expectedToken)
+		So(err, ShouldBeNil)
+	})
+
+	Convey("should return empty token if no header or cookie is set", t, func() {
+		req := httptest.NewRequest("GET", "http://localhost:8080", nil)
+
+		actual, err := GetCollectionID(req)
+
+		So(actual, ShouldBeEmpty)
+		So(err, ShouldBeNil)
+	})
+
+	Convey("should return empty token and error if get header returns an error that is not ErrHeaderNotFound", t, func() {
+		actual, err := GetCollectionID(nil)
+
+		So(actual, ShouldBeEmpty)
+		So(err, ShouldResemble, headers.ErrRequestNil)
+	})
+}
+
+func TestGetCollectionIDFromCookie(t *testing.T) {
+	expectedToken := "foo"
+
+	Convey("should return collection id from request cookie", t, func() {
+		req := httptest.NewRequest("GET", "http://localhost:8080", nil)
+		req.AddCookie(&http.Cookie{Name: CollectionIDCookieKey, Value: expectedToken})
+
+		actual, err := getCollectionIDFromCookie(req)
+
+		So(actual, ShouldEqual, expectedToken)
+		So(err, ShouldBeNil)
+	})
+
+	Convey("should return empty id if collection id cookie not found", t, func() {
+		req := httptest.NewRequest("GET", "http://localhost:8080", nil)
+
+		actual, err := getCollectionIDFromCookie(req)
+
+		So(actual, ShouldBeEmpty)
+		So(err, ShouldBeNil)
+	})
+}

--- a/request/locale.go
+++ b/request/locale.go
@@ -26,7 +26,7 @@ func SetLocaleCode(req *http.Request) *http.Request {
 }
 
 // GetLocaleCode will grab the locale code from the request
-func GetLocaleCode(r *http.Request) string{
+func GetLocaleCode(r *http.Request) string {
 	locale := GetLangFromSubDomain(r)
 
 	// Language is overridden by cookie 'lang' here if present.

--- a/request/locale.go
+++ b/request/locale.go
@@ -17,17 +17,23 @@ const (
 
 var SupportedLanguages = [2]string{LangEN, LangCY}
 
-// SetLocaleCode sets the Locale code used to set the language
+// SetLocaleCode will fetch the locale code and then sets it
 func SetLocaleCode(req *http.Request) *http.Request {
-	localeCode := GetLangFromSubDomain(req)
-
-	// Language is overridden by cookie 'lang' here if present.
-	if c, err := req.Cookie(LocaleCookieKey); err == nil && len(c.Value) > 0 {
-		localeCode = GetLangFromCookieOrDefault(c)
-	}
+	localeCode := GetLocaleCode(req)
 	req.Header.Set(LocaleHeaderKey, localeCode)
 
 	return req
+}
+
+// GetLocaleCode will grab the locale code from the request
+func GetLocaleCode(r *http.Request) string{
+	locale := GetLangFromSubDomain(r)
+
+	// Language is overridden by cookie 'lang' here if present.
+	if c, err := r.Cookie(LocaleCookieKey); err == nil && len(c.Value) > 0 {
+		locale = GetLangFromCookieOrDefault(c)
+	}
+	return locale
 }
 
 // GetLangFromSubDomain returns a language based on subdomain

--- a/request/locale_test.go
+++ b/request/locale_test.go
@@ -124,3 +124,80 @@ func TestSetLocaleCode(t *testing.T) {
 	})
 
 }
+
+func TestGetLocaleCode(t *testing.T) {
+
+	Convey("given a request on cy domain", t, func() {
+		req, _ := http.NewRequest("GET", "http://cy.localhost:21800/jobs", nil)
+		Convey(" and given a cookie containing 'en' lang", func() {
+			cookie := http.Cookie{Name: "lang", Value: LangEN}
+			req.AddCookie(&cookie)
+			localeCode := GetLocaleCode(req)
+			Convey("then lang returns a string 'en'", func() {
+				So(localeCode, ShouldEqual, LangEN)
+			})
+
+		})
+		Convey("and given a cookie containing 'cy' lang", func() {
+			cookie := http.Cookie{Name: "lang", Value: LangCY}
+			req.AddCookie(&cookie)
+			localeCode := GetLocaleCode(req)
+			Convey("then lang returns a string 'cy'", func() {
+				So(localeCode, ShouldEqual, LangCY)
+			})
+		})
+	})
+
+	Convey("given a request on no subdomain", t, func() {
+		req, _ := http.NewRequest("GET", "http://localhost:21800/jobs", nil)
+		Convey(" and given a cookie containing 'en' lang", func() {
+			cookie := http.Cookie{Name: "lang", Value: LangEN}
+			req.AddCookie(&cookie)
+			localeCode := GetLocaleCode(req)
+			Convey("then lang returns a string 'en'", func() {
+				So(localeCode, ShouldEqual, LangEN)
+			})
+
+		})
+		Convey("and given a cookie containing 'cy' lang", func() {
+			cookie := http.Cookie{Name: "lang", Value: LangCY}
+			req.AddCookie(&cookie)
+			localeCode := GetLocaleCode(req)
+			Convey("then lang returns a string 'cy'", func() {
+				So(localeCode, ShouldEqual, LangCY)
+			})
+		})
+	})
+
+	Convey("given a request on cy subdomain", t, func() {
+		req, _ := http.NewRequest("GET", "http://cy.localhost:21800/jobs", nil)
+		Convey(" and no cookie set", func() {
+			localeCode := GetLocaleCode(req)
+			Convey("then lang returns a string 'cy'", func() {
+				So(localeCode, ShouldEqual, LangCY)
+			})
+		})
+	})
+
+	Convey("given a request on no subdomain", t, func() {
+		req, _ := http.NewRequest("GET", "http://localhost:21800/jobs", nil)
+		Convey(" and no cookie set", func() {
+			localeCode := GetLocaleCode(req)
+			Convey("then lang returns a string 'en'", func() {
+				So(localeCode, ShouldEqual, LangEN)
+			})
+		})
+	})
+
+	Convey("given a request on no subdomain", t, func() {
+		req, _ := http.NewRequest("GET", "http://localhost:21800/jobs", nil)
+		Convey(" and cookie set to invalid/unused localeCode cookie set", func() {
+			cookie := http.Cookie{Name: "lang", Value: "foo"}
+			req.AddCookie(&cookie)
+			localeCode := GetLocaleCode(req)
+			Convey("then lang returns a string 'en'", func() {
+				So(localeCode, ShouldEqual, LangEN)
+			})
+		})
+	})
+}


### PR DESCRIPTION
### What

A new middleware handler has been added for frontend controller usage.
This middleware ensures that language is always set (defaults if not set) and will log warnings if Florence Access Tokens or Collection IDs are not present.

### How to review
This can be seen working here: https://github.com/ONSdigital/dp-frontend-homepage-controller/pull/43 on the homepage controller. Note that the PR is failing due to the need of this dp-net PR needing to be pulled into develep, which will happen once this is approved.

Check the tests give full coverage to new code. Ensure that this won't break anything

#### How to use

1. From an app create an implementation of ControllerHandlerFunc.
2. Call ControllerHandler passing in the implementation of ControllerHandlerFunc
3. Magic to occur
4. Note how localeCode, Florence Access token and Collection ID headers are all set.

### Who can review

Anyone who is comfortable with middleware and GO