### PR TITLE
Added patch struct and validation

### DIFF
--- a/request/patch.go
+++ b/request/patch.go
@@ -1,0 +1,72 @@
+package request
+
+import (
+	"fmt"
+)
+
+// PatchOp - iota enum of possible patch operations
+type PatchOp int
+
+// Possible patch operations
+const (
+	OpAdd PatchOp = iota
+	OpRemove
+	OpReplace
+	OpMove
+	OpCopy
+	OpTest
+)
+
+var validOps = []string{"add", "remove", "replace", "move", "copy", "test"}
+
+// ErrInvalidOp is an error returned when a patch contains a wrong 'op'
+var ErrInvalidOp = fmt.Errorf("operation is missing or not valid. Please, provide one of the following: %v", validOps)
+
+// ErrMissingMember generates an error for a missing member
+func ErrMissingMember(members []string) error {
+	return fmt.Errorf("missing member(s) in patch: %v", members)
+}
+
+func (o PatchOp) String() string {
+	return validOps[o]
+}
+
+// Patch models an HTTP patch operation request, according to RFC 6902
+type Patch struct {
+	Op    string   `json:"op"`
+	Path  string   `json:"path"`
+	From  string   `json:"from"`
+	Value []string `json:"value"`
+}
+
+// Validate checks that the provided operation is correct and the expected members are provided
+func (p *Patch) Validate() error {
+	missing := []string{}
+	switch p.Op {
+	case OpAdd.String(), OpReplace.String(), OpTest.String():
+		if p.Path == "" {
+			missing = append(missing, "path")
+		}
+		if p.Value == nil {
+			missing = append(missing, "value")
+		}
+	case OpRemove.String():
+		if p.Path == "" {
+			missing = append(missing, "path")
+		}
+	case OpMove.String(), OpCopy.String():
+		if p.Path == "" {
+			missing = append(missing, "path")
+		}
+		if p.From == "" {
+			missing = append(missing, "from")
+		}
+	default:
+		return ErrInvalidOp
+	}
+
+	if len(missing) > 0 {
+		return ErrMissingMember(missing)
+	}
+	return nil
+}

--- a/request/patch_test.go
+++ b/request/patch_test.go
@@ -1,0 +1,60 @@
+package request
+
+import (
+	"testing"
+
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+func TestPatch(t *testing.T) {
+
+	Convey("Validating a valid patch struct is successful", t, func() {
+		patch := Patch{
+			Op:    "add",
+			Path:  "/a/b/c",
+			Value: []string{"foo"},
+		}
+		So(patch.Validate(), ShouldBeNil)
+	})
+
+	Convey("Validating a patch struct with an invalid op fails with the expected error", t, func() {
+		patch := Patch{
+			Op:    "wrong",
+			Path:  "/a/b/c",
+			Value: []string{"foo"},
+		}
+		So(patch.Validate(), ShouldResemble, ErrInvalidOp)
+	})
+
+	Convey("Validating a patch struct with missing members for an operation results in the expected error being returned", t, func() {
+		patch := Patch{
+			Op:   "add",
+			Path: "/a/b/c",
+		}
+		So(patch.Validate(), ShouldResemble, ErrMissingMember([]string{"value"}))
+		patch = Patch{
+			Op:    "replace",
+			Value: []string{"foo"},
+		}
+		So(patch.Validate(), ShouldResemble, ErrMissingMember([]string{"path"}))
+		patch = Patch{
+			Op: "test",
+		}
+		So(patch.Validate(), ShouldResemble, ErrMissingMember([]string{"path", "value"}))
+		patch = Patch{
+			Op: "remove",
+		}
+		So(patch.Validate(), ShouldResemble, ErrMissingMember([]string{"path"}))
+		patch = Patch{
+			Op:   "move",
+			Path: "/a/b/c",
+		}
+		So(patch.Validate(), ShouldResemble, ErrMissingMember([]string{"from"}))
+		patch = Patch{
+			Op:   "copy",
+			From: "/c/b/a",
+		}
+		So(patch.Validate(), ShouldResemble, ErrMissingMember([]string{"path"}))
+	})
+
+}

--- a/request/patch_test.go
+++ b/request/patch_test.go
@@ -8,13 +8,13 @@ import (
 
 func TestPatch(t *testing.T) {
 
-	Convey("Validating a valid patch struct is successful", t, func() {
+	Convey("Validating a valid patch with a supported op is successful", t, func() {
 		patch := Patch{
 			Op:    "add",
 			Path:  "/a/b/c",
 			Value: []string{"foo"},
 		}
-		So(patch.Validate(), ShouldBeNil)
+		So(patch.Validate(OpAdd), ShouldBeNil)
 	})
 
 	Convey("Validating a patch struct with an invalid op fails with the expected error", t, func() {
@@ -26,35 +26,44 @@ func TestPatch(t *testing.T) {
 		So(patch.Validate(), ShouldResemble, ErrInvalidOp)
 	})
 
+	Convey("Validating a valid patch with an unsupported op fails with the expected error", t, func() {
+		patch := Patch{
+			Op:    "add",
+			Path:  "/a/b/c",
+			Value: []string{"foo"},
+		}
+		So(patch.Validate(OpRemove), ShouldResemble, ErrUnsupportedOp("add", []PatchOp{OpRemove}))
+	})
+
 	Convey("Validating a patch struct with missing members for an operation results in the expected error being returned", t, func() {
 		patch := Patch{
 			Op:   "add",
 			Path: "/a/b/c",
 		}
-		So(patch.Validate(), ShouldResemble, ErrMissingMember([]string{"value"}))
+		So(patch.Validate(OpAdd), ShouldResemble, ErrMissingMember([]string{"value"}))
 		patch = Patch{
 			Op:    "replace",
 			Value: []string{"foo"},
 		}
-		So(patch.Validate(), ShouldResemble, ErrMissingMember([]string{"path"}))
+		So(patch.Validate(OpReplace), ShouldResemble, ErrMissingMember([]string{"path"}))
 		patch = Patch{
 			Op: "test",
 		}
-		So(patch.Validate(), ShouldResemble, ErrMissingMember([]string{"path", "value"}))
+		So(patch.Validate(OpTest), ShouldResemble, ErrMissingMember([]string{"path", "value"}))
 		patch = Patch{
 			Op: "remove",
 		}
-		So(patch.Validate(), ShouldResemble, ErrMissingMember([]string{"path"}))
+		So(patch.Validate(OpRemove), ShouldResemble, ErrMissingMember([]string{"path"}))
 		patch = Patch{
 			Op:   "move",
 			Path: "/a/b/c",
 		}
-		So(patch.Validate(), ShouldResemble, ErrMissingMember([]string{"from"}))
+		So(patch.Validate(OpMove), ShouldResemble, ErrMissingMember([]string{"from"}))
 		patch = Patch{
 			Op:   "copy",
 			From: "/c/b/a",
 		}
-		So(patch.Validate(), ShouldResemble, ErrMissingMember([]string{"path"}))
+		So(patch.Validate(OpCopy), ShouldResemble, ErrMissingMember([]string{"path"}))
 	})
 
 }


### PR DESCRIPTION
### What

- Created generic patch operation struct and validation, according to [RFC6902](https://tools.ietf.org/html/rfc6902),
except for the following:
  - Value is assumed to be always a list of strings
- Validation accepts a list of supported ops for a particular patch

### How to review

- Make sure code changes make sense
- Make sure unit tests pass

### Who can review

Anyone