### PR TITLE
reverseProxy can now make use of modify response

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ this client should have a familiar feel to it when it is used - with an example 
 below:
 
 ```go
-import http "github.com/ONSdigital/dp-net/http"
+import http "github.com/ONSdigital/dp-net/v2/http"
 
 func httpHandlerFunc(w http.ResponseWriter, req *http.Request) {
     client := http.NewClient()
@@ -47,7 +47,7 @@ how to configure your own dp-net/http client:
 ```go
 import (
     "net/http"
-    dphttp "github.com/ONSdigital/dp-net/http"
+    dphttp "github.com/ONSdigital/dp-net/v2/http"
 )
 
 func main() {
@@ -89,7 +89,7 @@ This Server is intended to be used by all ONS digital publishing services that r
 Assuming you have created a router with your API handlers, you can create the http server like so:
 
 ```go
-import http "github.com/ONSdigital/dp-net/http"
+import http "github.com/ONSdigital/dp-net/v2/http"
     ...
     httpServer := http.NewServer(bindAddr, router)
     httpServer.HandleOSSignals = false

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.16
 
 require (
 	github.com/ONSdigital/dp-api-clients-go v1.28.0
+	github.com/ONSdigital/dp-net v1.0.7 // indirect
 	github.com/ONSdigital/log.go v1.0.1
 	github.com/gorilla/mux v1.8.0
 	github.com/justinas/alice v1.2.0

--- a/go.mod
+++ b/go.mod
@@ -4,9 +4,7 @@ go 1.16
 
 require (
 	github.com/ONSdigital/dp-api-clients-go v1.28.0
-	github.com/ONSdigital/dp-net v1.0.7 // indirect
 	github.com/ONSdigital/log.go v1.0.1
-	github.com/facebookgo/freeport v0.0.0-20150612182905-d4adf43b75b9
 	github.com/gorilla/mux v1.8.0
 	github.com/justinas/alice v1.2.0
 	github.com/pkg/errors v0.9.1

--- a/go.mod
+++ b/go.mod
@@ -1,9 +1,10 @@
-module github.com/ONSdigital/dp-net
+module github.com/ONSdigital/dp-net/v2
 
-go 1.13
+go 1.16
 
 require (
 	github.com/ONSdigital/dp-api-clients-go v1.28.0
+	github.com/ONSdigital/dp-net v1.0.7 // indirect
 	github.com/ONSdigital/log.go v1.0.1
 	github.com/facebookgo/freeport v0.0.0-20150612182905-d4adf43b75b9
 	github.com/gorilla/mux v1.8.0

--- a/go.sum
+++ b/go.sum
@@ -7,6 +7,7 @@ github.com/ONSdigital/dp-mocking v0.0.0-20190905163309-fee2702ad1b9/go.mod h1:Bc
 github.com/ONSdigital/dp-net v1.0.5-0.20200805082802-e518bc287596/go.mod h1:wDVhk2pYosQ1q6PXxuFIRYhYk2XX5+1CeRRnXpSczPY=
 github.com/ONSdigital/dp-net v1.0.5-0.20200805145012-9227a11caddb/go.mod h1:MrSZwDUvp8u1VJEqa+36Gwq4E7/DdceW+BDCvGes6Cs=
 github.com/ONSdigital/dp-net v1.0.5-0.20200805150805-cac050646ab5/go.mod h1:de3LB9tedE0tObBwa12dUOt5rvTW4qQkF5rXtt4b6CE=
+github.com/ONSdigital/dp-net v1.0.7 h1:K7yBQfA5zkm6mvK4ZM0GGm9XPj7Aexbe9wXYXwOjgfI=
 github.com/ONSdigital/dp-net v1.0.7/go.mod h1:1QFzx32FwPKD2lgZI6MtcsUXritsBdJihlzIWDrQ/gc=
 github.com/ONSdigital/go-ns v0.0.0-20191104121206-f144c4ec2e58 h1:XHnzoC7TxueLAfkBpblPiwaIxjngGv1VNVZhvE4jY6w=
 github.com/ONSdigital/go-ns v0.0.0-20191104121206-f144c4ec2e58/go.mod h1:iWos35il+NjbvDEqwtB736pyHru0MPFE/LqcwkV1wDc=

--- a/go.sum
+++ b/go.sum
@@ -9,11 +9,9 @@ github.com/ONSdigital/dp-net v1.0.5-0.20200805145012-9227a11caddb/go.mod h1:MrSZ
 github.com/ONSdigital/dp-net v1.0.5-0.20200805150805-cac050646ab5/go.mod h1:de3LB9tedE0tObBwa12dUOt5rvTW4qQkF5rXtt4b6CE=
 github.com/ONSdigital/dp-net v1.0.7 h1:K7yBQfA5zkm6mvK4ZM0GGm9XPj7Aexbe9wXYXwOjgfI=
 github.com/ONSdigital/dp-net v1.0.7/go.mod h1:1QFzx32FwPKD2lgZI6MtcsUXritsBdJihlzIWDrQ/gc=
-github.com/ONSdigital/go-ns v0.0.0-20191104121206-f144c4ec2e58 h1:XHnzoC7TxueLAfkBpblPiwaIxjngGv1VNVZhvE4jY6w=
 github.com/ONSdigital/go-ns v0.0.0-20191104121206-f144c4ec2e58/go.mod h1:iWos35il+NjbvDEqwtB736pyHru0MPFE/LqcwkV1wDc=
 github.com/ONSdigital/log.go v1.0.0/go.mod h1:UnGu9Q14gNC+kz0DOkdnLYGoqugCvnokHBRBxFRpVoQ=
 github.com/ONSdigital/log.go v1.0.1-0.20200805084515-ee61165ea36a/go.mod h1:dDnQATFXCBOknvj6ZQuKfmDhbOWf3e8mtV+dPEfWJqs=
-github.com/ONSdigital/log.go v1.0.1-0.20200805145532-1f25087a0744 h1:Wf92VblikYm5lv2fw9+No+2MUr/noAK/KI34qHQ6OHQ=
 github.com/ONSdigital/log.go v1.0.1-0.20200805145532-1f25087a0744/go.mod h1:y4E9MYC+cV9VfjRD0UBGj8PA7H3wABqQi87/ejrDhYc=
 github.com/ONSdigital/log.go v1.0.1 h1:SZ5wRZAwlt2jQUZ9AUzBB/PL+iG15KapfQpJUdA18/4=
 github.com/ONSdigital/log.go v1.0.1/go.mod h1:dIwSXuvFB5EsZG5x44JhsXZKMd80zlb0DZxmiAtpL4M=
@@ -38,7 +36,6 @@ github.com/mattn/go-isatty v0.0.8/go.mod h1:Iq45c/XA43vh69/j3iqttzPXn0bhXyGjM0Hd
 github.com/mattn/go-isatty v0.0.11 h1:FxPOTFNqGkuDUGi3H/qkUbQO4ZiBa2brKq5r0l8TGeM=
 github.com/mattn/go-isatty v0.0.11/go.mod h1:PhnuNfih5lzO57/f3n+odYbM4JtupLOxQOAqxQCu2WE=
 github.com/mgutz/ansi v0.0.0-20170206155736-9520e82c474b/go.mod h1:01TrycV0kFyexm33Z7vhZRXopbI8J3TDReVlkTgMUxE=
-github.com/mgutz/ansi v0.0.0-20200706080929-d51e80ef957d h1:5PJl274Y63IEHC+7izoQE9x6ikvDFZS2mDVS3drnohI=
 github.com/mgutz/ansi v0.0.0-20200706080929-d51e80ef957d/go.mod h1:01TrycV0kFyexm33Z7vhZRXopbI8J3TDReVlkTgMUxE=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
@@ -50,7 +47,6 @@ golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACk
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/net v0.0.0-20190311183353-d8887717615a/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
-golang.org/x/net v0.0.0-20200324143707-d3edc9973b7e h1:3G+cUijn7XD+S4eJFddp53Pv7+slrESplyjG25HgL+k=
 golang.org/x/net v0.0.0-20200324143707-d3edc9973b7e/go.mod h1:qpuaurCH72eLCgpAm/N6yyVIVM9cpaDIP3A8BGJEC5A=
 golang.org/x/net v0.0.0-20200822124328-c89045814202 h1:VvcQYSHwXgi7W+TpUR6A9g6Up98WAHf3f/ulnJ62IyA=
 golang.org/x/net v0.0.0-20200822124328-c89045814202/go.mod h1:/O7V0waA8r7cgGh81Ro3o1hOxt32SMVPicZroKQ2sZA=

--- a/handlers/README.md
+++ b/handlers/README.md
@@ -76,7 +76,7 @@ Wrap authenticated endpoints using the `handlers.CheckIdentity(handler)` functio
 Add required headers to outbound requests to other services
 
 ```go
-    import "github.com/ONSdigital/dp-net/request"
+    import "github.com/ONSdigital/dp-net/v2/request"
 
     request.AddServiceTokenHeader(req, api.AuthToken)
     request.AddUserHeader(req, "UserA")
@@ -98,8 +98,8 @@ If you need to use the middleware component in unit tests you can call the const
 ```go
 import (
     clientsidentity "github.com/ONSdigital/dp-api-clients-go/identity"
-    dphttp "github.com/ONSdigital/dp-net/http"
-    dphandlers "github.com/ONSdigital/dp-net/handlers"
+    dphttp "github.com/ONSdigital/dp-net/v2/http"
+    dphandlers "github.com/ONSdigital/dp-net/v2/handlers"
 )
 
 httpClient := &dphttp.ClienterMock{

--- a/handlers/authentication.go
+++ b/handlers/authentication.go
@@ -5,8 +5,8 @@ import (
 	"net/http"
 	"strings"
 
-	dphttp "github.com/ONSdigital/dp-net/http"
-	request "github.com/ONSdigital/dp-net/request"
+	dphttp "github.com/ONSdigital/dp-net/v2/http"
+	request "github.com/ONSdigital/dp-net/v2/request"
 	"github.com/ONSdigital/log.go/log"
 	"github.com/gorilla/mux"
 )

--- a/handlers/authentication_test.go
+++ b/handlers/authentication_test.go
@@ -8,7 +8,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	dprequest "github.com/ONSdigital/dp-net/request"
+	dprequest "github.com/ONSdigital/dp-net/v2/request"
 	"github.com/ONSdigital/log.go/log"
 	. "github.com/smartystreets/goconvey/convey"
 )

--- a/handlers/handlers.go
+++ b/handlers/handlers.go
@@ -2,7 +2,7 @@ package handlers
 
 import (
 	"context"
-	"github.com/ONSdigital/dp-net/request"
+	"github.com/ONSdigital/dp-net/v2/request"
 	"github.com/ONSdigital/log.go/log"
 	"net/http"
 )

--- a/handlers/handlers_test.go
+++ b/handlers/handlers_test.go
@@ -3,7 +3,7 @@ package handlers
 import (
 	"context"
 	"fmt"
-	dprequest "github.com/ONSdigital/dp-net/request"
+	dprequest "github.com/ONSdigital/dp-net/v2/request"
 
 	"net/http"
 	"net/http/httptest"

--- a/handlers/identity.go
+++ b/handlers/identity.go
@@ -7,8 +7,8 @@ import (
 	"github.com/ONSdigital/dp-api-clients-go/headers"
 
 	clientsidentity "github.com/ONSdigital/dp-api-clients-go/identity"
-	dphttp "github.com/ONSdigital/dp-net/http"
-	dprequest "github.com/ONSdigital/dp-net/request"
+	dphttp "github.com/ONSdigital/dp-net/v2/http"
+	dprequest "github.com/ONSdigital/dp-net/v2/request"
 	"github.com/ONSdigital/log.go/log"
 )
 

--- a/handlers/identity_test.go
+++ b/handlers/identity_test.go
@@ -16,7 +16,7 @@ import (
 
 	healthcheck "github.com/ONSdigital/dp-api-clients-go/health"
 	clientsidentity "github.com/ONSdigital/dp-api-clients-go/identity"
-	dphttp "github.com/ONSdigital/dp-net/http"
+	dphttp "github.com/ONSdigital/dp-net/v2/http"
 	dprequest "github.com/ONSdigital/dp-net/request"
 	"github.com/pkg/errors"
 	. "github.com/smartystreets/goconvey/convey"

--- a/handlers/identity_test.go
+++ b/handlers/identity_test.go
@@ -4,9 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
-
 	"github.com/ONSdigital/dp-api-clients-go/headers"
-
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
@@ -16,11 +14,14 @@ import (
 
 	healthcheck "github.com/ONSdigital/dp-api-clients-go/health"
 	clientsidentity "github.com/ONSdigital/dp-api-clients-go/identity"
+	dprequest "github.com/ONSdigital/dp-net/request"
 	dphttp "github.com/ONSdigital/dp-net/v2/http"
-	dprequest "github.com/ONSdigital/dp-net/v2/request"
 	"github.com/pkg/errors"
 	. "github.com/smartystreets/goconvey/convey"
 )
+// TODO bump dp-net/request to dp-net/v2/request once the dp-api-clients has been bumped to use dp-net /v2
+// Can't do this yet as context key is set with v1 dp-net and would be read by v2 dp-net and so technically would be
+// different and cause tests to fail
 
 const (
 	url                = "/whatever"

--- a/handlers/identity_test.go
+++ b/handlers/identity_test.go
@@ -17,7 +17,7 @@ import (
 	healthcheck "github.com/ONSdigital/dp-api-clients-go/health"
 	clientsidentity "github.com/ONSdigital/dp-api-clients-go/identity"
 	dphttp "github.com/ONSdigital/dp-net/v2/http"
-	dprequest "github.com/ONSdigital/dp-net/request"
+	dprequest "github.com/ONSdigital/dp-net/v2/request"
 	"github.com/pkg/errors"
 	. "github.com/smartystreets/goconvey/convey"
 )

--- a/handlers/mapping.go
+++ b/handlers/mapping.go
@@ -1,7 +1,7 @@
 package handlers
 
 import (
-	request "github.com/ONSdigital/dp-net/request"
+	request "github.com/ONSdigital/dp-net/v2/request"
 )
 
 // Key - iota enum of possible sets of keys for middleware manipulation

--- a/handlers/response/writer_test.go
+++ b/handlers/response/writer_test.go
@@ -6,7 +6,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/ONSdigital/dp-net/handlers/response"
+	"github.com/ONSdigital/dp-net/v2/handlers/response"
 	. "github.com/smartystreets/goconvey/convey"
 )
 

--- a/handlers/reverseproxy/reverseproxy.go
+++ b/handlers/reverseproxy/reverseproxy.go
@@ -8,7 +8,7 @@ import (
 	"time"
 )
 
-func Create(proxyURL *url.URL, directorFunc func(*http.Request)) http.Handler {
+func Create(proxyURL *url.URL, directorFunc func(*http.Request), modifyResponseFunc func(*http.Response) error) http.Handler {
 	proxy := httputil.NewSingleHostReverseProxy(proxyURL)
 	director := proxy.Director
 	proxy.Transport = &http.Transport{
@@ -29,5 +29,9 @@ func Create(proxyURL *url.URL, directorFunc func(*http.Request)) http.Handler {
 			directorFunc(req)
 		}
 	}
+	if modifyResponseFunc != nil {
+		proxy.ModifyResponse = modifyResponseFunc
+	}
+
 	return proxy
 }

--- a/handlers/reverseproxy/reverseproxy_test.go
+++ b/handlers/reverseproxy/reverseproxy_test.go
@@ -6,14 +6,14 @@ import (
 	"net/url"
 	"testing"
 
-	"github.com/ONSdigital/dp-net/handlers/reverseproxy"
+	"github.com/ONSdigital/dp-net/v2/handlers/reverseproxy"
 	. "github.com/smartystreets/goconvey/convey"
 )
 
 func TestDirectorFunc(t *testing.T) {
 	proxyURL, _ := url.Parse("https://www.ons.gov.uk")
 	Convey("Create proxy", t, func() {
-		reverseProxy := reverseproxy.Create(proxyURL, nil)
+		reverseProxy := reverseproxy.Create(proxyURL, nil, nil)
 
 		So(reverseProxy, ShouldNotBeNil)
 		So(reverseProxy, ShouldImplement, (*http.Handler)(nil))
@@ -28,6 +28,8 @@ func TestDirectorFunc(t *testing.T) {
 		reverseProxy := reverseproxy.Create(proxyURL, func(req *http.Request) {
 			directorCalled = true
 			req.URL.Host = `host`
+		}, func(req *http.Response) error {
+			return nil
 		})
 
 		So(reverseProxy, ShouldNotBeNil)
@@ -36,7 +38,6 @@ func TestDirectorFunc(t *testing.T) {
 		req, _ := http.NewRequest(`GET`, `https://cy.ons.gov.uk`, nil)
 		So(func() { reverseProxy.(*httputil.ReverseProxy).Director(req) }, ShouldNotPanic)
 		So(req.URL.Host, ShouldEqual, `host`)
-
 		So(directorCalled, ShouldBeTrue)
 	})
 }

--- a/http/client.go
+++ b/http/client.go
@@ -12,7 +12,7 @@ import (
 	"strings"
 	"time"
 
-	request "github.com/ONSdigital/dp-net/request"
+	request "github.com/ONSdigital/dp-net/v2/request"
 	"golang.org/x/net/context"
 	"golang.org/x/net/context/ctxhttp"
 )

--- a/http/client_test.go
+++ b/http/client_test.go
@@ -11,8 +11,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/ONSdigital/dp-net/http/httptest"
-	request "github.com/ONSdigital/dp-net/request"
+	"github.com/ONSdigital/dp-net/v2/http/httptest"
+	request "github.com/ONSdigital/dp-net/v2/request"
 	. "github.com/smartystreets/goconvey/convey"
 )
 

--- a/http/server.go
+++ b/http/server.go
@@ -8,7 +8,7 @@ import (
 
 	"context"
 
-	request "github.com/ONSdigital/dp-net/request"
+	request "github.com/ONSdigital/dp-net/v2/request"
 	"github.com/ONSdigital/log.go/log"
 	"github.com/justinas/alice"
 )


### PR DESCRIPTION
### What

The reverseProxy wrapper now allows a modifyResponse function to be sent to the underlining reverseProxy. This is needed so Florence server-side can set secure httpOnly cookies based on the response headers from other services that it proxies to.

This is a breaking change as it changes the reverseProxy Create function signature. As such the module has been bumped to a major new release v2

Go modules upgraded to 1.16 as part of this

### Who can review

Anyone except me
