### PR TITLE
use v1 ContextKey type definition to prevent different services using…

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ The package also includes http utilities like constants, error definitions, a re
 
 ### Client
 
-The dp-net/http Client provides for robust contextual HTTP, and a default client
+The dp-net/v2/http Client provides for robust contextual HTTP, and a default client
 that inherits the methods associated with the standard HTTP client,
 but with the addition of production-ready timeouts and context-sensitivity,
 and the ability to perform exponential backoff when calling another HTTP server.
@@ -42,7 +42,7 @@ and this will be noticed by the client.
 
 You also do not have to use the default client if you don't like the configured
 timeouts or do not wish to use exponential backoff. The following example shows
-how to configure your own dp-net/http client:
+how to configure your own dp-net/v2/http client:
 
 ```go
 import (

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/ONSdigital/dp-net/v2
 go 1.16
 
 require (
-	github.com/ONSdigital/dp-api-clients-go v1.34.3
+	github.com/ONSdigital/dp-api-clients-go/v2 v2.1.7-beta
 	github.com/ONSdigital/dp-net v1.0.12
 	github.com/ONSdigital/log.go/v2 v2.0.5
 	github.com/gorilla/mux v1.8.0

--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,8 @@
 github.com/ONSdigital/dp-api-clients-go v1.28.0/go.mod h1:iyJy6uRL4B6OYOJA0XMr5UHt6+Q8XmN9uwmURO+9Oj4=
 github.com/ONSdigital/dp-api-clients-go v1.34.3 h1:nS3ZG3Eql9T68Q0IFehpnqkUy2AFoTDktVgaD90Yj+s=
 github.com/ONSdigital/dp-api-clients-go v1.34.3/go.mod h1:kX+YKuoLYLfkeLHMvQKRRydZVxO7ZEYyYiwG2xhV51E=
+github.com/ONSdigital/dp-api-clients-go/v2 v2.1.7-beta h1:YVM5n4wi4FBIM5Wx8BkU4Pu/Hzkv5oiwyG2V+ibN598=
+github.com/ONSdigital/dp-api-clients-go/v2 v2.1.7-beta/go.mod h1:p9Ig0jUJmOXYpsZFZkb+mBeUgNBKoTiTVqHt1kJlVrM=
 github.com/ONSdigital/dp-healthcheck v1.0.5 h1:DXnohGIqXaLLeYGdaGOhgkZjAbWMNoLAjQ3EgZeMT3M=
 github.com/ONSdigital/dp-healthcheck v1.0.5/go.mod h1:2wbVAUHMl9+4tWhUlxYUuA1dnf2+NrwzC+So5f5BMLk=
 github.com/ONSdigital/dp-mocking v0.0.0-20190905163309-fee2702ad1b9 h1:+WXVfTDyWXY1DQRDFSmt1b/ORKk5c7jGiPu7NoeaM/0=

--- a/handlers/README.md
+++ b/handlers/README.md
@@ -89,7 +89,7 @@ or, put less portably:
     req.Header.Add("User-Identity", "UserA")
 ```
 
-But most of this should be done by `dp-net/http` and `dp-api-clients-go/...`.
+But most of this should be done by `dp-net/v2/http` and `dp-api-clients-go/v2/...`.
 
 ### Testing
 
@@ -97,7 +97,7 @@ If you need to use the middleware component in unit tests you can call the const
 
 ```go
 import (
-    clientsidentity "github.com/ONSdigital/dp-api-clients-go/identity"
+    clientsidentity "github.com/ONSdigital/dp-api-clients-go/v2/identity"
     dphttp "github.com/ONSdigital/dp-net/v2/http"
     dphandlers "github.com/ONSdigital/dp-net/v2/handlers"
 )

--- a/handlers/identity.go
+++ b/handlers/identity.go
@@ -4,9 +4,9 @@ import (
 	"context"
 	"net/http"
 
-	"github.com/ONSdigital/dp-api-clients-go/headers"
+	"github.com/ONSdigital/dp-api-clients-go/v2/headers"
 
-	clientsidentity "github.com/ONSdigital/dp-api-clients-go/identity"
+	clientsidentity "github.com/ONSdigital/dp-api-clients-go/v2/identity"
 	dphttp "github.com/ONSdigital/dp-net/v2/http"
 	dprequest "github.com/ONSdigital/dp-net/v2/request"
 	"github.com/ONSdigital/log.go/v2/log"

--- a/handlers/identity_test.go
+++ b/handlers/identity_test.go
@@ -4,24 +4,22 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
-	"github.com/ONSdigital/dp-api-clients-go/headers"
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"testing"
 
+	"github.com/ONSdigital/dp-api-clients-go/v2/headers"
+
 	"io"
 
-	healthcheck "github.com/ONSdigital/dp-api-clients-go/health"
-	clientsidentity "github.com/ONSdigital/dp-api-clients-go/identity"
-	dprequest "github.com/ONSdigital/dp-net/request"
+	healthcheck "github.com/ONSdigital/dp-api-clients-go/v2/health"
+	clientsidentity "github.com/ONSdigital/dp-api-clients-go/v2/identity"
 	dphttp "github.com/ONSdigital/dp-net/v2/http"
+	dprequest "github.com/ONSdigital/dp-net/v2/request"
 	"github.com/pkg/errors"
 	. "github.com/smartystreets/goconvey/convey"
 )
-// TODO bump dp-net/request to dp-net/v2/request once the dp-api-clients has been bumped to use dp-net /v2
-// Can't do this yet as context key is set with v1 dp-net and would be read by v2 dp-net and so technically would be
-// different and cause tests to fail
 
 const (
 	url                = "/whatever"

--- a/handlers/mapping.go
+++ b/handlers/mapping.go
@@ -1,7 +1,8 @@
 package handlers
 
 import (
-	request "github.com/ONSdigital/dp-net/v2/request"
+	request "github.com/ONSdigital/dp-net/request"
+	v1request "github.com/ONSdigital/dp-net/request"
 )
 
 // Key - iota enum of possible sets of keys for middleware manipulation
@@ -11,7 +12,7 @@ type Key int
 type KeyMap struct {
 	Header  string
 	Cookie  string
-	Context request.ContextKey
+	Context v1request.ContextKey
 }
 
 // Possible values for sets of keys

--- a/request/collection.go
+++ b/request/collection.go
@@ -1,8 +1,9 @@
 package request
 
 import (
-	"github.com/ONSdigital/dp-api-clients-go/headers"
 	"net/http"
+
+	"github.com/ONSdigital/dp-api-clients-go/v2/headers"
 )
 
 // CollectionID header and cookie keys

--- a/request/collection_test.go
+++ b/request/collection_test.go
@@ -1,10 +1,11 @@
 package request
 
 import (
-	"github.com/ONSdigital/dp-api-clients-go/headers"
 	"net/http"
 	"net/http/httptest"
 	"testing"
+
+	"github.com/ONSdigital/dp-api-clients-go/v2/headers"
 
 	. "github.com/smartystreets/goconvey/convey"
 )

--- a/request/context_key.go
+++ b/request/context_key.go
@@ -1,14 +1,13 @@
 package request
 
-// ContextKey is an alias of type string
-type ContextKey string
+import v1request "github.com/ONSdigital/dp-net/request"
 
-// Context keys
+// Context keys - using type defined in v1 to prevent any type mismatch issue.
 const (
-	UserIdentityKey        = ContextKey("User-Identity")
-	CallerIdentityKey      = ContextKey("Caller-Identity")
-	RequestIdKey           = ContextKey("request-id")
-	FlorenceIdentityKey    = ContextKey("florence-id")
-	LocaleContextKey       = ContextKey(LocaleHeaderKey)
-	CollectionIDContextKey = ContextKey(CollectionIDHeaderKey)
+	UserIdentityKey        = v1request.ContextKey("User-Identity")
+	CallerIdentityKey      = v1request.ContextKey("Caller-Identity")
+	RequestIdKey           = v1request.ContextKey("request-id")
+	FlorenceIdentityKey    = v1request.ContextKey("florence-id")
+	LocaleContextKey       = v1request.ContextKey(LocaleHeaderKey)
+	CollectionIDContextKey = v1request.ContextKey(CollectionIDHeaderKey)
 )

--- a/request/request_test.go
+++ b/request/request_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	v1request "github.com/ONSdigital/dp-net/request"
 	. "github.com/smartystreets/goconvey/convey"
 )
 
@@ -43,7 +44,7 @@ func TestNewRequestID(t *testing.T) {
 func TestGetRequestId(t *testing.T) {
 	Convey("should return requestID if it exists in the provided context", t, func() {
 		ctx := WithRequestId(context.Background(), "666")
-		So(ctx.Value(ContextKey("request-id")).(string), ShouldEqual, "666")
+		So(ctx.Value(v1request.ContextKey("request-id")).(string), ShouldEqual, "666")
 	})
 
 	Convey("should return empty value if requestID is not in the provided context", t, func() {
@@ -55,11 +56,11 @@ func TestGetRequestId(t *testing.T) {
 func TestSetRequestId(t *testing.T) {
 	Convey("set request id in empty context", t, func() {
 		ctx := WithRequestId(context.Background(), "123")
-		So(ctx.Value(ContextKey("request-id")), ShouldEqual, "123")
+		So(ctx.Value(v1request.ContextKey("request-id")), ShouldEqual, "123")
 
 		Convey("overwrite context request id with new value", func() {
 			newCtx := WithRequestId(ctx, "456")
-			So(newCtx.Value(ContextKey("request-id")), ShouldEqual, "456")
+			So(newCtx.Value(v1request.ContextKey("request-id")), ShouldEqual, "456")
 		})
 	})
 }


### PR DESCRIPTION
… different types, and potentially breaking functionality

### What

- Remove ContextKey type definition from v2, and use v1 type definition instead
The reason for this is to prevent possible conflicts, which may result in functionality being broken (and not detected by any test). This happened when we migrated from go-ns to dp-net.

- Also upgraded dp-api-clients-go dependencies to v2, which can be done as they are also using dp-net v1 ContextKey type.

### How to review

- Make sure code changes make sense
- Make sure unit tests pass

### Who can review

anyone