### PR TITLE
add responder package

### DIFF
--- a/responder/callback.go
+++ b/responder/callback.go
@@ -1,0 +1,139 @@
+package responder
+
+import (
+	"errors"
+	"strconv"
+	"fmt"
+	"net/http"
+	"reflect"
+
+	"github.com/ONSdigital/log.go/v2/log"
+)
+
+// unwrapStatusCode is a callback function that allows you to extract
+// a status code from an error. If the status code returned is 0,
+// statusCode will attempt to recursively unwrap the error until a
+// non-zero code is returned. If no more code is embedded it will
+// return status 500 as default.
+func unwrapStatusCode(err error) int {
+	if code := statusCode(err); code != 0 {
+		return code
+	}
+
+	for errors.Unwrap(err) != nil {
+		if code := statusCode(err); code != 0 {
+			return code
+		}
+		err = errors.Unwrap(err)
+	}
+
+	return http.StatusInternalServerError
+}
+
+// statusCode attempts to extract a status code from an error,
+// or returns 0 if not found
+func statusCode(err error) int {
+	var cerr coder
+
+	if errors.As(err, &cerr) {
+		return cerr.Code()
+	}
+
+	return 0
+}
+
+// logData returns logData for an error if there is any. This is used
+// to extract log.Data embedded in an error if it implements the dataLogger
+// interface
+func logData(err error) log.Data {
+	var lderr dataLogger
+	if errors.As(err, &lderr) {
+		return lderr.LogData()
+	}
+
+	return nil
+}
+
+// unwrapLogData recursively unwraps logData from an error. This allows an
+// error to be wrapped with log.Data at each level of the call stack, and
+// then extracted and combined here as a single log.Data entry. This allows
+// us to log errors only once but maintain the context provided by log.Data
+// at each level.
+func unwrapLogData(err error) log.Data {
+	var data []log.Data
+
+	for err != nil && errors.Unwrap(err) != nil {
+		if lderr, ok := err.(dataLogger); ok {
+			if d := lderr.LogData(); d != nil {
+				data = append(data, d)
+			}
+		}
+
+		err = errors.Unwrap(err)
+	}
+
+	// flatten []log.Data into single log.Data with slice
+	// entries for duplicate keyed entries, but not for duplicate
+	// key-value pairs
+	logData := log.Data{}
+	for _, d := range data {
+		for k, v := range d {
+			if val, ok := logData[k]; ok {
+				if !reflect.DeepEqual(val, v) {
+					if s, ok := val.([]interface{}); ok {
+						s = append(s, v)
+						logData[k] = s
+					} else {
+						logData[k] = []interface{}{val, v}
+					}
+				}
+			} else {
+				logData[k] = v
+			}
+		}
+	}
+
+	return logData
+}
+
+// errorResponse extracts a specified error response to be returned
+// to the caller if present, otherwise returns the default error
+// string
+func errorMessage(err error) string {
+	var rerr messager
+	if errors.As(err, &rerr) {
+		if resp := rerr.Message(); resp != "" {
+			return resp
+		}
+	}
+
+	return err.Error()
+}
+
+// stackTrace recursively unwraps the error looking for the deepest
+// level at which the error was wrapped with a stack trace from
+// github.com/pkg/errors (or conforms to the StackTracer interface)
+// and returns the slice of stack frames. These can are of type
+// log.go/EventStackTrace so can be used directly with log.Go's
+// available API to preserve the correct error logging format
+func stackTrace(err error) []log.EventStackTrace{
+	var serr stacktracer
+	var resp []log.EventStackTrace
+
+	for errors.Unwrap(err) != nil && errors.As(err, &serr) {
+		st := serr.StackTrace()
+		resp = make([]log.EventStackTrace, 0)
+		for _, f := range st{
+			line, _ := strconv.Atoi(fmt.Sprintf("%d",  f))
+			resp = append(resp, log.EventStackTrace{
+				File:     fmt.Sprintf("%+s", f),
+				Function: fmt.Sprintf("%n",  f),
+				Line:     line,
+			})
+		}
+
+		err = errors.Unwrap(err)
+	}
+
+	return resp
+}

--- a/responder/callback_test.go
+++ b/responder/callback_test.go
@@ -1,0 +1,197 @@
+package responder
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/ONSdigital/log.go/v2/log"
+
+	"github.com/pkg/errors"
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+type testError struct {
+	err        error
+	statusCode int
+	logData    map[string]interface{}
+}
+
+func (e testError) Error() string {
+	if e.err == nil {
+		return "nil"
+	}
+	return e.err.Error()
+}
+
+func (e testError) Unwrap() error {
+	return e.err
+}
+
+func (e testError) Code() int {
+	return e.statusCode
+}
+
+func (e testError) LogData() map[string]interface{} {
+	return e.logData
+}
+
+func TestUnwrapLogDataHappy(t *testing.T) {
+
+	Convey("Given an error with embedded logData", t, func() {
+		err := &testError{
+			logData: log.Data{
+				"log": "data",
+			},
+		}
+
+		Convey("When logData(err) is called", func() {
+			ld := logData(err)
+			So(ld, ShouldResemble, log.Data{"log": "data"})
+		})
+	})
+
+	Convey("Given an error chain with wrapped logData", t, func() {
+		err1 := &testError{
+			err: errors.New("original error"),
+			logData: log.Data{
+				"log": "data",
+			},
+		}
+
+		err2 := &testError{
+			err: fmt.Errorf("err1: %w", err1),
+			logData: log.Data{
+				"additional": "data",
+			},
+		}
+
+		err3 := &testError{
+			err: fmt.Errorf("err2: %w", err2),
+			logData: log.Data{
+				"final": "data",
+			},
+		}
+
+		Convey("When unwrapLogData(err) is called", func() {
+			logData := unwrapLogData(err3)
+			expected := log.Data{
+				"final":      "data",
+				"additional": "data",
+				"log":        "data",
+			}
+
+			So(logData, ShouldResemble, expected)
+		})
+	})
+
+	Convey("Given an error chain with intermittent wrapped logData", t, func() {
+		err1 := &testError{
+			err: errors.New("original error"),
+			logData: log.Data{
+				"log": "data",
+			},
+		}
+
+		err2 := &testError{
+			err: fmt.Errorf("err1: %w", err1),
+		}
+
+		err3 := &testError{
+			err: fmt.Errorf("err2: %w", err2),
+			logData: log.Data{
+				"final": "data",
+			},
+		}
+
+		Convey("When unwrapLogData(err) is called", func() {
+			logData := unwrapLogData(err3)
+			expected := log.Data{
+				"final": "data",
+				"log":   "data",
+			}
+
+			So(logData, ShouldResemble, expected)
+		})
+	})
+
+	Convey("Given an error chain with wrapped logData with duplicate key values", t, func() {
+		err1 := &testError{
+			err: errors.New("original error"),
+			logData: log.Data{
+				"log":        "data",
+				"duplicate":  "duplicate_data1",
+				"request_id": "ADB45F",
+			},
+		}
+
+		err2 := &testError{
+			err: fmt.Errorf("err1: %w", err1),
+			logData: log.Data{
+				"additional": "data",
+				"duplicate":  "duplicate_data2",
+				"request_id": "ADB45F",
+			},
+		}
+
+		err3 := &testError{
+			err: fmt.Errorf("err2: %w", err2),
+			logData: log.Data{
+				"final":      "data",
+				"duplicate":  "duplicate_data3",
+				"request_id": "ADB45F",
+			},
+		}
+
+		Convey("When unwrapLogData(err) is called", func() {
+			logData := unwrapLogData(err3)
+			expected := log.Data{
+				"final":      "data",
+				"additional": "data",
+				"log":        "data",
+				"duplicate": []interface{}{
+					"duplicate_data3",
+					"duplicate_data2",
+					"duplicate_data1",
+				},
+				"request_id": "ADB45F",
+			}
+
+			So(logData, ShouldResemble, expected)
+		})
+	})
+}
+
+func TestStackTraceHappy(t *testing.T){
+	Convey("Given an error with embedded stack trace from pkg/errors", t, func() {
+		err := testCallStackFunc1()
+		Convey("When stackTrace(err) is called", func() {
+			st := stackTrace(err)
+			So(len(st), ShouldEqual, 19)
+			
+			So(st[0].File, ShouldContainSubstring, "dp-cantabular-filter-flex-api/responder/callback_test.go")
+			So(st[0].Line, ShouldEqual, 195)
+			So(st[0].Function, ShouldEqual, "testCallStackFunc3")
+
+			So(st[1].File, ShouldContainSubstring, "dp-cantabular-filter-flex-api/responder/callback_test.go")
+			So(st[1].Line, ShouldEqual, 191)
+			So(st[1].Function, ShouldEqual, "testCallStackFunc2")
+
+			So(st[2].File, ShouldContainSubstring, "dp-cantabular-filter-flex-api/responder/callback_test.go")
+			So(st[2].Line, ShouldEqual, 187)
+			So(st[2].Function, ShouldEqual, "testCallStackFunc1")
+		})
+	})
+}
+
+func testCallStackFunc1() error{
+	return testCallStackFunc2()
+}
+
+func testCallStackFunc2() error{
+	return testCallStackFunc3()
+}
+
+func testCallStackFunc3() error{
+	cause := errors.New("I am the cause")
+	return errors.Wrap(cause, "I am the context")
+}

--- a/responder/contract.go
+++ b/responder/contract.go
@@ -1,0 +1,6 @@
+package responder
+
+// errorResponse is the generic ONS error response for HTTP errors
+type errorResponse struct {
+	Errors []string `json:"errors"`
+}

--- a/responder/error.go
+++ b/responder/error.go
@@ -1,0 +1,43 @@
+package responder
+
+// Error is the packages error type
+type Error struct{
+	err        error
+	message    string
+	statusCode int
+	logData    map[string]interface{}
+}
+
+// Error satisfies the standard library Go error interface
+func (e Error) Error() string{
+	if e.err == nil{
+		return "nil"
+	}
+	return e.err.Error()
+}
+
+// Unwrap implements the standard library Go unwrapper interface
+func (e Error) Unwrap() error{
+	return e.err
+}
+
+// Code satisfies the coder interface which is used to recover a
+// HTTP status code from an error
+func (e Error) Code() int{
+	return e.statusCode
+}
+
+// Message satisfies the messager interface which is used to specify
+// a response to be sent to the caller in place of the error text for a
+// given error. This is useful when you don't want sensitive information
+// or implementation details being exposed to the caller which could be
+// used to find exploits in our API
+func (e Error) Message() string{
+	return e.message
+}
+
+// LogData satisfies the dataLogger interface which is used to recover
+// log data from an error
+func (e Error) LogData() map[string]interface{}{
+	return e.logData
+}

--- a/responder/interface.go
+++ b/responder/interface.go
@@ -1,0 +1,21 @@
+package responder
+
+import (
+	"github.com/pkg/errors"
+)
+
+type dataLogger interface {
+	LogData() map[string]interface{}
+}
+
+type coder interface {
+	Code() int
+}
+
+type messager interface {
+	Message() string
+}
+
+type stacktracer interface {
+	StackTrace() errors.StackTrace
+}

--- a/responder/responder.go
+++ b/responder/responder.go
@@ -1,0 +1,155 @@
+package responder
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+
+	"github.com/ONSdigital/log.go/v2/log"
+	"github.com/pkg/errors"
+)
+
+// Responder is responsible for responding to http requests, providing methods for responding
+// in with JSON and handling errors
+type Responder struct{}
+
+// New returns a new responder
+func New() *Responder {
+	return &Responder{}
+}
+
+// JSON responds to a HTTP request, expecting the response body
+// to be marshall-able into JSON
+func (r *Responder) JSON(ctx context.Context, w http.ResponseWriter, status int, resp interface{}){
+	b, err := json.Marshal(resp)
+	if err != nil {
+		respondError(ctx, w, Error{
+			statusCode: http.StatusInternalServerError,
+			err:        errors.Wrap(err, "failed to marshal response"),
+			message:    "Internal Server Error: Badly formed reponse attempt",
+			logData: log.Data{
+				"response": resp,
+			},
+		})
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json; charset=utf-8")
+	w.WriteHeader(status)
+
+	if _, err = w.Write(b); err != nil {
+		log.Error(ctx, "failed to write response", err, log.Data{
+			"response": string(b),
+		})
+		return
+	}
+}
+
+// Error responds with a single error, formatted to fit in ONS's desired error
+// response structure (essentially an array of errors)
+func (r *Responder) Error(ctx context.Context, w http.ResponseWriter, err error) {
+	respondError(ctx, w, err)
+}
+
+// respondError is the implementation of Error, seperated so it can be used internally
+// by the other respond functions without having to create a new Responder
+func respondError(ctx context.Context, w http.ResponseWriter, err error){
+	log.Info(ctx, "error responding to HTTP request", log.ERROR, &log.EventErrors{{
+			Message:    err.Error(),
+			StackTrace: stackTrace(err),
+			Data:       unwrapLogData(err),
+		}},
+	)
+
+	status := unwrapStatusCode(err)
+	msg    := errorMessage(err)
+	resp   := errorResponse{
+		Errors: []string{msg},
+	}
+
+	logData := log.Data{
+		"error":       err.Error(),
+		"response":    msg,
+		"status_code": status,
+	}
+
+	b, err := json.Marshal(resp)
+	if err != nil {
+		log.Error(ctx, "badly formed error response", err, logData)
+		http.Error(w, msg, status)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json; charset=utf-8")
+	w.WriteHeader(status)
+
+	if _, err := w.Write(b); err != nil {
+		log.Error(ctx, "failed to write error response", err, logData)
+		return
+	}
+
+	log.Info(ctx, "returned error response", logData)
+}
+
+// Errors responds with a slice of errors formatted to ONS's desired error response structure.
+// Note you will have to pass a slice of []error rather than slice of []{some type that implements
+// error}. The underlying structs can be any type that implements error but the slice itself must be
+// defined as []error
+func (r *Responder) Errors(ctx context.Context, w http.ResponseWriter, status int, errs []error){
+	var errorLogs log.EventErrors
+	var errorMsgs []string
+
+	for _, err := range errs{
+		errorLogs = append(errorLogs,log.EventError{
+			Message:    err.Error(),
+			StackTrace: stackTrace(err),
+			Data:       unwrapLogData(err),
+		})
+		errorMsgs = append(errorMsgs, errorMessage(err))
+	}
+
+	log.Info(ctx, "error responding to HTTP request", log.ERROR, &errorLogs)
+
+	resp   := errorResponse{
+		Errors: errorMsgs,
+	}
+
+	logData := log.Data{
+		"response":    resp,
+		"status_code": status,
+	}
+
+	b, err := json.Marshal(resp)
+	if err != nil {
+		log.Error(ctx, "badly formed error response", err, logData)
+		http.Error(w, "unexpected error", status)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json; charset=utf-8")
+	w.WriteHeader(status)
+
+	if _, err := w.Write(b); err != nil {
+		log.Error(ctx, "failed to write error response", err, logData)
+		return
+	}
+
+	log.Info(ctx, "returned error response", logData)
+}
+
+// Bytes responds to a http request with the raw bytes of whatever's passed as
+// resp. Can be used to respond with a raw string, bytes, pre-encoded object etc
+func (r *Responder) Bytes(ctx context.Context, w http.ResponseWriter, status int, resp []byte){
+	w.WriteHeader(status)
+	if _, err := w.Write(resp); err != nil {
+		log.Error(ctx, "failed to write response", err, log.Data{
+			"response": string(resp),
+		})
+		return
+	}
+}
+
+// StatusCode responds with a raw status code
+func (r *Responder) StatusCode(w http.ResponseWriter, status int){
+	w.WriteHeader(status)
+}

--- a/responder/responder_test.go
+++ b/responder/responder_test.go
@@ -1,0 +1,201 @@
+package responder_test
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/ONSdigital/dp-net/v2/responder"
+
+
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+type testResponse struct {
+	Message string `json:"message"`
+}
+
+type testError struct {
+	err  error
+	msg  string
+	code int
+}
+
+func (e testError) Error() string {
+	if e.err == nil {
+		return ""
+	}
+	return e.err.Error()
+}
+
+func (e testError) Code() int {
+	return e.code
+}
+
+func (e testError) Message() string {
+	return e.msg
+}
+
+func TestJSON(t *testing.T) {
+	r := responder.New()
+
+	Convey("Given a valid context and response writer", t, func() {
+		ctx := context.Background()
+		w := httptest.NewRecorder()
+
+		Convey("Given a valid JSON response object", func() {
+			resp := testResponse{
+				Message: "Hello, World!",
+			}
+
+			Convey("when RespondJSON is called with a given statusCode", func() {
+				statusCode := http.StatusCreated
+
+				r.JSON(ctx, w, statusCode, resp)
+
+				Convey("the response writer should record the appropriate status code and response body", func() {
+					expectedCode := http.StatusCreated
+					expectedBody := `{"message":"Hello, World!"}`
+
+					So(w.Code, ShouldEqual, expectedCode)
+					So(w.Body.String(), ShouldResemble, expectedBody)
+				})
+
+			})
+		})
+
+		Convey("Given an invalid JSON response object", func() {
+			resp := make(chan int, 3)
+
+			Convey("when RespondJSON is called with a given statusCode", func() {
+				statusCode := http.StatusCreated
+
+				r.JSON(ctx, w, statusCode, resp)
+
+				Convey("the response writer should record an error status code and response body", func() {
+					expectedCode := http.StatusInternalServerError
+					expectedBody := `{"errors":["Internal Server Error: Badly formed reponse attempt"]}`
+
+					So(w.Code, ShouldEqual, expectedCode)
+					So(w.Body.String(), ShouldResemble, expectedBody)
+				})
+			})
+		})
+	})
+}
+
+
+
+func TestError(t *testing.T) {
+
+	r := responder.New()
+
+	Convey("Given a valid context and response writer", t, func() {
+		ctx := context.Background()
+		w := httptest.NewRecorder()
+
+		Convey("Given a standard Go error", func() {
+			err := errors.New("test error")
+
+			Convey("when Error() is called", func() {
+				r.Error(ctx, w, err)
+
+				Convey("the response writer should record status code 500 and appropriate error response body", func() {
+					expectedCode := http.StatusInternalServerError
+					expectedBody := `{"errors":["test error"]}`
+
+					So(w.Code, ShouldEqual, expectedCode)
+					So(w.Body.String(), ShouldResemble, expectedBody)
+				})
+
+			})
+		})
+
+		Convey("Given an error that satisfies interfaces providing Code() and Response() functions", func() {
+			err := testError{
+				err:  errors.New("test error"),
+				msg: "test response",
+				code: http.StatusUnauthorized,
+			}
+
+			Convey("when Error() is called", func() {
+				r.Error(ctx, w, err)
+
+				Convey("the response writer should record the appropriate status code and response message", func() {
+					expectedCode := http.StatusUnauthorized
+					expectedBody := `{"errors":["test response"]}`
+
+					So(w.Code, ShouldEqual, expectedCode)
+					So(w.Body.String(), ShouldResemble, expectedBody)
+				})
+			})
+		})
+	})
+}
+
+func TestErrors(t *testing.T) {
+
+	r := responder.New()
+
+	Convey("Given a valid context and response writer", t, func() {
+		ctx := context.Background()
+		w := httptest.NewRecorder()
+
+		Convey("Given a slice of standard Go errors", func() {
+			errs := []error{
+				errors.New("test error 1"),
+				errors.New("test error 2"),
+				errors.New("test error 3"),
+			}
+
+			Convey("when Errors() is called with given status code and errors", func() {
+				r.Errors(ctx, w, http.StatusUnauthorized, errs)
+
+				Convey("the response writer should record appropriate status code and error response body", func() {
+					expectedCode := http.StatusUnauthorized
+					expectedBody := `{"errors":["test error 1","test error 2","test error 3"]}`
+
+					So(w.Code, ShouldEqual, expectedCode)
+					So(w.Body.String(), ShouldResemble, expectedBody)
+				})
+
+			})
+		})
+
+		Convey("Given an slice errors that satisfy an interface providing a Response() function", func() {
+			testErrs := []testError{
+				{
+					err:  errors.New("test error 1"),
+					msg: "test response 1",
+				},
+				{
+					err:  errors.New("test error 2"),
+					msg: "test response 2",
+				},
+				{
+					err:  errors.New("test error 3"),
+					msg: "test response 3",
+				},
+			}
+
+			var errs []error
+			for _, err := range testErrs{
+				errs = append(errs, err)
+			}
+
+			Convey("when Errors() is called", func() {
+				r.Errors(ctx, w, http.StatusForbidden, errs)
+
+				Convey("the response writer should record the appropriate status code and response message", func() {
+					expectedCode := http.StatusForbidden
+					expectedBody := `{"errors":["test response 1","test response 2","test response 3"]}`
+
+					So(w.Code, ShouldEqual, expectedCode)
+					So(w.Body.String(), ShouldResemble, expectedBody)
+				})
+			})
+		})
+	})
+}


### PR DESCRIPTION
### What

Created a proposal to add this package to dp-net.

So far it is being used amongst the new Cantabular API services in a copy-and-paste manner and feel it would be more appropriate in a shared repository. I think it would be a useful too to use in upcoming services and will allow for streamlining responding to requests and encouraging some consistency.
Provides functionality to allow a cleaner handling of errors with regards to status codes and logging with data. 
Also useful as it can be injected into middleware as well as handlers.

Features:

- Exposes functionality which allows the user to respond to HTTP requests in a consistent manner.
- Provides methods for responding as JSON, raw bytes, status code, and single and multiple Error responses
- Error response allows user to embed status code, log data, and tailored error message into the error type provided
and deals with all 3 at once by:
    - Logging the error with attached log data
    - Writing attached status code
    - Formatting errors to ONS error response type `{"errors":["err1", "err2"]}
    - Allows for responding with tailored error message(s) or with original error text by omitting

### How to review

Check code makes sense, tests pass anything missing?

To see usage/implementation checkout out develop branches of `dp-cantabular-dimension-api` and `dp-cantabular-filter-flex-api` in the cantabular-compose stack and experiment with the endpoints.

### Who can review

Describe who worked on the changes, so that other people can review.
