### PR TITLE
return status 500 if pass as 0 in responder.Error

### DIFF
--- a/errors/callback_stacktrace_test.go
+++ b/errors/callback_stacktrace_test.go
@@ -26,15 +26,15 @@ func TestStackTraceHappy(t *testing.T) {
 			So(len(st), ShouldEqual, 19)
 
 			So(st[0].File, ShouldContainSubstring, packagePath+"/"+fileName)
-			So(st[0].Line, ShouldEqual, 70)
+			So(st[0].Line, ShouldEqual, 69)
 			So(st[0].Function, ShouldEqual, "testCallStackFunc3")
 
 			So(st[1].File, ShouldContainSubstring, packagePath+"/"+fileName)
-			So(st[1].Line, ShouldEqual, 66)
+			So(st[1].Line, ShouldEqual, 65)
 			So(st[1].Function, ShouldEqual, "testCallStackFunc2")
 
 			So(st[2].File, ShouldContainSubstring, packagePath+"/"+fileName)
-			So(st[2].Line, ShouldEqual, 62)
+			So(st[2].Line, ShouldEqual, 61)
 			So(st[2].Function, ShouldEqual, "testCallStackFunc1")
 		})
 	})
@@ -46,11 +46,11 @@ func TestStackTraceHappy(t *testing.T) {
 			So(len(st), ShouldEqual, 18)
 
 			So(st[0].File, ShouldContainSubstring, packagePath+"/"+fileName)
-			So(st[0].Line, ShouldEqual, 70)
+			So(st[0].Line, ShouldEqual, 69)
 			So(st[0].Function, ShouldEqual, "testCallStackFunc3")
 
 			So(st[1].File, ShouldContainSubstring, packagePath+"/"+fileName)
-			So(st[1].Line, ShouldEqual, 75)
+			So(st[1].Line, ShouldEqual, 74)
 			So(st[1].Function, ShouldEqual, "testCallStackFunc4")
 
 		})

--- a/responder/responder.go
+++ b/responder/responder.go
@@ -59,8 +59,11 @@ func respondError(ctx context.Context, w http.ResponseWriter, status int, err er
 		Message:    err.Error(),
 		StackTrace: dperrors.StackTrace(err),
 		Data:       dperrors.UnwrapLogData(err),
-	}},
-	)
+	}})
+
+	if status == 0 {
+		status = http.StatusInternalServerError
+	}
 
 	msg := dperrors.ErrorMessage(err)
 	resp := errorResponse{

--- a/responder/responder_test.go
+++ b/responder/responder_test.go
@@ -103,6 +103,19 @@ func TestError(t *testing.T) {
 				})
 
 			})
+
+			Convey("when Error() is called with status code 0", func() {
+				r.Error(ctx, w, 0, err)
+
+				Convey("the response writer should record status 500 and appropriate error response body", func() {
+					expectedCode := http.StatusInternalServerError
+					expectedBody := `{"errors":["test error"]}`
+
+					So(w.Code, ShouldEqual, expectedCode)
+					So(w.Body.String(), ShouldResemble, expectedBody)
+				})
+
+			})
 		})
 
 		Convey("Given an error that satisfies interface providing Response() function", func() {


### PR DESCRIPTION
### What

Added small addtion to catch status code as 0 and return 500 in responder.Error.

This can happen if you're attempting to dynamically assert a status code and it returns a 0.

### How to review

Check change makes sense, test passes.

### Who can review

Anyone
