### PR TITLE
Add logs for debugging header problem

### DIFF
--- a/http/client.go
+++ b/http/client.go
@@ -3,6 +3,7 @@ package http
 //go:generate moq -out mock_client.go . Clienter
 
 import (
+	"fmt"
 	"io"
 	"math"
 	"math/rand"
@@ -74,6 +75,7 @@ func NewClient() Clienter {
 }
 
 func NewClientWithAwsSigner(awsFilename, awsProfile, awsRegion, awsService string) (Clienter, error) {
+	fmt.Println("bug check - inside the AWS signer")
 	newClient := *DefaultClient
 	awsRoundTripper, err := NewAWSSignerRoundTripper(awsFilename, awsProfile, awsRegion, awsService, DefaultTransport)
 	if err != nil {
@@ -94,6 +96,7 @@ func ClientWithTimeout(c Clienter, timeout time.Duration) Clienter {
 
 // Clienter roundtripper calls the httpclient roundtripper.
 func (c *Client) RoundTrip(req *http.Request) (*http.Response, error) {
+	fmt.Println("bug check - inside RoundTrip")
 	return c.HTTPClient.Transport.RoundTrip(req)
 }
 

--- a/http/client.go
+++ b/http/client.go
@@ -96,7 +96,7 @@ func ClientWithTimeout(c Clienter, timeout time.Duration) Clienter {
 
 // Clienter roundtripper calls the httpclient roundtripper.
 func (c *Client) RoundTrip(req *http.Request) (*http.Response, error) {
-	fmt.Println("bug check - inside RoundTrip")
+	fmt.Printf("bug check - inside RoundTrip: %s", req.Header.Get("Authorization"))
 	return c.HTTPClient.Transport.RoundTrip(req)
 }
 

--- a/http/custom_roundtripper.go
+++ b/http/custom_roundtripper.go
@@ -38,6 +38,7 @@ func NewAWSSignerRoundTripper(awsFilename, awsProfile, awsRegion, awsService str
 }
 
 func (srt *AwsSignerRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	fmt.Println("bug check - inside the AWS signer round tripper")
 	var body []byte
 	var err error
 	if req.Body != nil {

--- a/http/custom_roundtripper.go
+++ b/http/custom_roundtripper.go
@@ -38,7 +38,8 @@ func NewAWSSignerRoundTripper(awsFilename, awsProfile, awsRegion, awsService str
 }
 
 func (srt *AwsSignerRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
-	fmt.Println("bug check - inside the AWS signer round tripper")
+	fmt.Printf("bug check - inside the AWS signer round tripper: %s", req.Header.Get("Authorization"))
+
 	var body []byte
 	var err error
 	if req.Body != nil {


### PR DESCRIPTION
### What

Temporary logging added to help debug problem with zebedee auth being replaced by AWS auth in header  from Search API.

### Who can review

@rahulPalliyalil 
