### PR TITLE
Pass separate client objects for awsSigner and default http

### DIFF
--- a/http/custom_roundtripper.go
+++ b/http/custom_roundtripper.go
@@ -15,7 +15,6 @@ type AwsSignerRoundTripper struct {
 }
 
 func NewAWSSignerRoundTripper(awsFilename, awsProfile, awsRegion, awsService string, customTransport http.RoundTripper) (*AwsSignerRoundTripper, error) {
-	fmt.Println("inside aws signer..........................")
 	var roundTripper http.RoundTripper
 	if awsRegion == "" || awsService == "" {
 		return nil, fmt.Errorf("aws region and service should be valid options")
@@ -38,7 +37,6 @@ func NewAWSSignerRoundTripper(awsFilename, awsProfile, awsRegion, awsService str
 }
 
 func (srt *AwsSignerRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
-	fmt.Println("inside round tripper..........................")
 	var body []byte
 	var err error
 	if req.Body != nil {


### PR DESCRIPTION
### What

It is needed to pass separate client objects to clienter default client and aws signer client, otherwise the transport of the aws signer will overwrite the default client. transport, which will cause signing when it tries to call even custom endpoints.



### Who can review

@cookel2 
