### PR TITLE
Pass separate client objects for awsSigner and default http

### DIFF
--- a/http/custom_roundtripper.go
+++ b/http/custom_roundtripper.go
@@ -38,8 +38,6 @@ func NewAWSSignerRoundTripper(awsFilename, awsProfile, awsRegion, awsService str
 }
 
 func (srt *AwsSignerRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
-	fmt.Printf("bug check - inside the AWS signer round tripper: %s", req.Header.Get("Authorization"))
-
 	var body []byte
 	var err error
 	if req.Body != nil {


### PR DESCRIPTION
### What

It is needed to pass separate client objects to clienter default client and aws signer client, otherwise the transport of the aws signer will overwrite the default client. transport, which will cause signing when it tries to call even custom endpoints.

### Who can review

Anyone except me
