### PR TITLE
Add unwrap error message to callback and utilise in responder

### DIFF
--- a/errors/callback.go
+++ b/errors/callback.go
@@ -94,17 +94,36 @@ func StackTrace(err error) []log.EventStackTrace {
 }
 
 // ErrorMessage extracts a specified error response to be returned
-// to the caller if present, otherwise returns the default error
-// string
+// to the caller if present, otherwise returns an empty string
 func ErrorMessage(err error) string {
 	var rerr messager
 	if errors.As(err, &rerr) {
-		if resp := rerr.Message(); resp != "" {
-			return resp
-		}
+		return rerr.Message()
 	}
 
-	return err.Error()
+	return ""
+}
+
+// UnwrapErrorMessage is a callback function that allows you to extract
+// an error message from an error. If the error message returned is an empty
+// string, UnwrapErrorMessage will attempt to recursively unwrap the error
+// until a non-empty string is returned. If no message is returned it will
+// return the original error's error string as default.
+func UnwrapErrorMessage(err error) string {
+	originalErr := err
+
+	if msg := ErrorMessage(err); msg != "" {
+		return msg
+	}
+
+	for errors.Unwrap(err) != nil {
+		if msg := ErrorMessage(err); msg != "" {
+			return msg
+		}
+		err = errors.Unwrap(err)
+	}
+
+	return originalErr.Error()
 }
 
 // UnwrapStatusCode is a callback function that allows you to extract

--- a/responder/responder.go
+++ b/responder/responder.go
@@ -65,7 +65,7 @@ func respondError(ctx context.Context, w http.ResponseWriter, status int, err er
 		status = http.StatusInternalServerError
 	}
 
-	msg := dperrors.ErrorMessage(err)
+	msg := dperrors.UnwrapErrorMessage(err)
 	resp := errorResponse{
 		Errors: []string{msg},
 	}
@@ -108,7 +108,7 @@ func (r *Responder) Errors(ctx context.Context, w http.ResponseWriter, status in
 			StackTrace: dperrors.StackTrace(err),
 			Data:       dperrors.UnwrapLogData(err),
 		})
-		errorMsgs = append(errorMsgs, dperrors.ErrorMessage(err))
+		errorMsgs = append(errorMsgs, dperrors.UnwrapErrorMessage(err))
 	}
 
 	log.Info(ctx, "error responding to HTTP request", log.ERROR, &errorLogs)


### PR DESCRIPTION
### What

Add UnwrapErrorMessage function to complement ErrorMessage callback and implement in responder.

Previously the function for recovering an error message from an error would return the error message for the first error in the chain that has a Message() function, whether or not the message was a blank string or not. Now UnwrapErrorMessage will recursively unwrap the errors until it finds a non-empty string before it defaults to the error's default Error() string.
This brings the behaviour in line with the UnwrapStatusCode behavour and means an error message can be recovered from an error that was wrapped with a message several calls up the stack.
Anywhere relying on existing behaviour of ErrorMessage() should be unchanged.

### How to review

Check change makes sense, tests pass

### Who can review

Anyone
