### PR TITLE
Add an overall request timeout

### DIFF
--- a/http/server.go
+++ b/http/server.go
@@ -16,8 +16,11 @@ import (
 const (
 	RequestIDHandlerKey string = "RequestID"
 	LogHandlerKey       string = "Log"
-	DefaultReadTimeout         = 5 * time.Second
-	DefaultWriteTimeout        = 10 * time.Second
+)
+
+var (
+	DefaultReadTimeout  = 5 * time.Second
+	DefaultWriteTimeout = 10 * time.Second
 )
 
 // Server is a http.Server with sensible defaults, which supports

--- a/http/server_test.go
+++ b/http/server_test.go
@@ -46,7 +46,7 @@ func TestNew(t *testing.T) {
 			s := NewServer(":0", h)
 
 			So(s, ShouldNotBeNil)
-			So(s.Handler, ShouldEqual, h)
+			So(s.Handler, ShouldHaveSameTypeAs, http.TimeoutHandler(h, DefaultWriteTimeout-100*time.Millisecond, "connection timeout"))
 			So(s.Alice, ShouldBeNil)
 			So(s.Addr, ShouldEqual, ":0")
 			So(s.MaxHeaderBytes, ShouldEqual, 0)

--- a/http/utils.go
+++ b/http/utils.go
@@ -3,6 +3,7 @@ package http
 import (
 	"io"
 	"io/ioutil"
+	"net"
 	"net/http"
 
 	"github.com/ONSdigital/log.go/v2/log"
@@ -24,4 +25,20 @@ func DrainBody(r *http.Request) {
 	if err != nil {
 		log.Error(r.Context(), "error closing request body", err)
 	}
+}
+
+// GetFreePort is simple utility to find a free port on the "localhost" interface of the host machine
+// for a local server to use. This is especially useful for testing purposes
+func GetFreePort() (port int, err error) {
+	var l *net.TCPListener
+
+	l, err = net.ListenTCP("tcp", &net.TCPAddr{IP: net.ParseIP(`127.0.0.1`)})
+	if err != nil {
+		return
+	}
+	defer func(l *net.TCPListener) {
+		err = l.Close()
+	}(l)
+
+	return l.Addr().(*net.TCPAddr).Port, nil
 }


### PR DESCRIPTION
### What

Add an overall request timeout so that if a write timeout will be triggered, the request will be terminated as well, and a response written, before the writer is closed, since there is no value in continuing if the writer has been closed.

### How to review

Review code

### Who can review

Anyone
