### PR TITLE
Fix for request timeout

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,8 @@ module github.com/ONSdigital/dp-net/v2
 
 go 1.19
 
+retract v2.7.0
+
 require (
 	github.com/ONSdigital/dp-api-clients-go/v2 v2.187.0
 	github.com/ONSdigital/log.go/v2 v2.2.0


### PR DESCRIPTION
### What

Add the timeout handler when performing the Server.ListenAndServe(), after the Server object has been created and the various timeout values, specifically the WriteTimeout, has been set by the client

### How to review

Review code and tests

### Who can review

Anyone
