### PR TITLE
Add identity handlers for service-only and florence-only requests

### DIFF
--- a/handlers/identity.go
+++ b/handlers/identity.go
@@ -26,6 +26,18 @@ func IdentityWithHTTPClient(cli *clientsidentity.Client) func(http.Handler) http
 	return identityWithHTTPClient(cli, GetFlorenceToken, getServiceAuthToken)
 }
 
+// IdentityService is a handler that controls the service authenticating of a request only,
+// florence token header or cookie will be ignored
+func IdentityService(cli *clientsidentity.Client) func(http.Handler) http.Handler {
+	return identityWithHTTPClient(cli, dontGetToken, getServiceAuthToken)
+}
+
+// IdentityFlorence is a handler that controls the florence (user) authenticating of a request only,
+// service token header or cookie will be ignored
+func IdentityFlorence(cli *clientsidentity.Client) func(http.Handler) http.Handler {
+	return identityWithHTTPClient(cli, GetFlorenceToken, dontGetToken)
+}
+
 func identityWithHTTPClient(cli *clientsidentity.Client, getFlorenceToken, getServiceToken getTokenFromReqFunc) func(http.Handler) http.Handler {
 	return func(h http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
@@ -71,6 +83,10 @@ func handleFailedRequest(ctx context.Context, w http.ResponseWriter, r *http.Req
 	log.Error(ctx, event, err, data)
 	dphttp.DrainBody(r)
 	w.WriteHeader(status)
+}
+
+func dontGetToken(ctx context.Context, req *http.Request) (string, error) {
+	return "", nil
 }
 
 func GetFlorenceToken(ctx context.Context, req *http.Request) (string, error) {


### PR DESCRIPTION
### What

Add identity handlers to validate service-only or florence-only requests.
- IdentityService: validates service tokens only. If not provided a 401 is returned, even if there is a florence token present.
- IdentityFlorence: validates florence tokens only. If not provided a 401 is returned, even if there is a service token present.

This is required by Feedback API - [trello card](https://trello.com/c/j8pKkXGy/1139-create-post-feedback-endpoint) which  is supposed to be used only by services.

### How to review

- Make sure changes make sense
- You may run Feedback api using this pr branch: https://github.com/ONSdigital/dp-feedback-api/pull/3 and validate that only requests with `Authorization` header are allowed, and with a valid `X-Florence-Token` token they are rejected. (or feel free to ask me for a demo)

### Who can review

Anyone