### PR TITLE
fix - retract v2.7.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.19
 retract (
 	v2.7.0
 	v2.7.1 // rethink application of timeout to standard  http server
+	v2.7.2 // contains retraction
 )
 
 require (

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.19
 
 retract (
 	v2.7.0
-	v2.7.1 // rethink application of timeout to standard  http server
+	v2.7.1 // TODO: rethink application of timeout to standard  http server
 	v2.7.2 // contains retraction
 )
 

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,10 @@ module github.com/ONSdigital/dp-net/v2
 
 go 1.19
 
-retract v2.7.0
+retract (
+	v2.7.0
+	v2.7.1 // rethink application of timeout to standard  http server
+)
 
 require (
 	github.com/ONSdigital/dp-api-clients-go/v2 v2.187.0


### PR DESCRIPTION
### What
dp-net v2.7.1, contains a change to add timeouts to the standard http server. However it adds this to every http server created rather than one with a non-standard timeout added.

### How to review
Eyeball

### Who can review
dp developer
