### PR TITLE
Limit whats logged to a sensible amount on a write response failure

### DIFF
--- a/responder/responder.go
+++ b/responder/responder.go
@@ -20,6 +20,8 @@ func New() *Responder {
 	return &Responder{}
 }
 
+const maxBodyLength = 1000 // used to limit max length of line to limit too much hittinh logstash
+
 // JSON responds to a HTTP request, expecting the response body
 // to be marshall-able into JSON
 func (r *Responder) JSON(ctx context.Context, w http.ResponseWriter, status int, resp interface{}) {
@@ -41,12 +43,12 @@ func (r *Responder) JSON(ctx context.Context, w http.ResponseWriter, status int,
 	if _, err = w.Write(b); err != nil {
 		var logData log.Data
 		bodyLength := len(b)
-		if bodyLength > 1000 {
+		if bodyLength > maxBodyLength {
 			// Limit length of the response that is logged to a useful amount to stop giving
 			// logstash a bad day as the dp-population-types-api has been seen to log a line
 			// that is ~1.9 M Bytes long - which is way too much.
 			logData = log.Data{
-				"truncated_response":       string(b[:1000]),
+				"truncated_response":       string(b[:maxBodyLength]),
 				"original_response_length": bodyLength,
 			}
 		} else {
@@ -161,12 +163,12 @@ func (r *Responder) Bytes(ctx context.Context, w http.ResponseWriter, status int
 	if _, err := w.Write(resp); err != nil {
 		var logData log.Data
 		bodyLength := len(resp)
-		if bodyLength > 1000 {
+		if bodyLength > maxBodyLength {
 			// Limit length of the response that is logged to a useful amount to stop giving
 			// logstash a bad day as the dp-population-types-api has been seen to log a line
 			// that is ~1.9 M Bytes long - which is way too much.
 			logData = log.Data{
-				"truncated_response":       string(resp[:1000]),
+				"truncated_response":       string(resp[:maxBodyLength]),
 				"original_response_length": bodyLength,
 			}
 		} else {

--- a/responder/responder.go
+++ b/responder/responder.go
@@ -40,7 +40,10 @@ func (r *Responder) JSON(ctx context.Context, w http.ResponseWriter, status int,
 
 	if _, err = w.Write(b); err != nil {
 		log.Error(ctx, "failed to write response", err, log.Data{
-			"response": string(b),
+			// Limit length of the response that is logged to a useful amount to stop giving
+			// logstash a bad day as the dp-population-types-api has been seen to log a line
+			// that is ~1.9 M Bytes long - which is way too much.
+			"response": string(b[0:1000]),
 		})
 		return
 	}
@@ -146,7 +149,10 @@ func (r *Responder) Bytes(ctx context.Context, w http.ResponseWriter, status int
 	w.WriteHeader(status)
 	if _, err := w.Write(resp); err != nil {
 		log.Error(ctx, "failed to write response", err, log.Data{
-			"response": string(resp),
+			// Limit length of the response that is logged to a useful amount to stop giving
+			// logstash a bad day as the dp-population-types-api has been seen to log a line
+			// that is ~1.9 M Bytes long - which is way too much.
+			"response": string(resp[0:1000]),
 		})
 		return
 	}

--- a/responder/responder.go
+++ b/responder/responder.go
@@ -39,11 +39,15 @@ func (r *Responder) JSON(ctx context.Context, w http.ResponseWriter, status int,
 	w.WriteHeader(status)
 
 	if _, err = w.Write(b); err != nil {
+		bodyLength := len(b)
+		if bodyLength > 1000 {
+			bodyLength = 1000
+		}
 		log.Error(ctx, "failed to write response", err, log.Data{
 			// Limit length of the response that is logged to a useful amount to stop giving
 			// logstash a bad day as the dp-population-types-api has been seen to log a line
 			// that is ~1.9 M Bytes long - which is way too much.
-			"response": string(b[0:1000]),
+			"response": string(b[0:bodyLength]),
 		})
 		return
 	}
@@ -148,11 +152,15 @@ func (r *Responder) Errors(ctx context.Context, w http.ResponseWriter, status in
 func (r *Responder) Bytes(ctx context.Context, w http.ResponseWriter, status int, resp []byte) {
 	w.WriteHeader(status)
 	if _, err := w.Write(resp); err != nil {
+		bodyLength := len(resp)
+		if bodyLength > 1000 {
+			bodyLength = 1000
+		}
 		log.Error(ctx, "failed to write response", err, log.Data{
 			// Limit length of the response that is logged to a useful amount to stop giving
 			// logstash a bad day as the dp-population-types-api has been seen to log a line
 			// that is ~1.9 M Bytes long - which is way too much.
-			"response": string(resp[0:1000]),
+			"response": string(resp[0:bodyLength]),
 		})
 		return
 	}

--- a/responder/responder.go
+++ b/responder/responder.go
@@ -3,6 +3,7 @@ package responder
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"net/http"
 
 	dperrors "github.com/ONSdigital/dp-net/v2/errors"
@@ -39,15 +40,17 @@ func (r *Responder) JSON(ctx context.Context, w http.ResponseWriter, status int,
 	w.WriteHeader(status)
 
 	if _, err = w.Write(b); err != nil {
+		responseDescription := "response"
 		bodyLength := len(b)
 		if bodyLength > 1000 {
+			responseDescription = fmt.Sprintf("response clipped to 1000 chars from: %d", bodyLength)
 			bodyLength = 1000
 		}
 		log.Error(ctx, "failed to write response", err, log.Data{
 			// Limit length of the response that is logged to a useful amount to stop giving
 			// logstash a bad day as the dp-population-types-api has been seen to log a line
 			// that is ~1.9 M Bytes long - which is way too much.
-			"response": string(b[0:bodyLength]),
+			responseDescription: string(b[0:bodyLength]),
 		})
 		return
 	}
@@ -152,15 +155,17 @@ func (r *Responder) Errors(ctx context.Context, w http.ResponseWriter, status in
 func (r *Responder) Bytes(ctx context.Context, w http.ResponseWriter, status int, resp []byte) {
 	w.WriteHeader(status)
 	if _, err := w.Write(resp); err != nil {
+		responseDescription := "response"
 		bodyLength := len(resp)
 		if bodyLength > 1000 {
+			responseDescription = fmt.Sprintf("response clipped to 1000 chars from: %d", bodyLength)
 			bodyLength = 1000
 		}
 		log.Error(ctx, "failed to write response", err, log.Data{
 			// Limit length of the response that is logged to a useful amount to stop giving
 			// logstash a bad day as the dp-population-types-api has been seen to log a line
 			// that is ~1.9 M Bytes long - which is way too much.
-			"response": string(resp[0:bodyLength]),
+			responseDescription: string(resp[0:bodyLength]),
 		})
 		return
 	}


### PR DESCRIPTION
### What

dp-population-types-api-web has been seen to produce a stupidly long log line on a failure to write response of 1914357 bytes.
And such long log lines can cause logstash a bad day.

This change (once dp-population-types-api uses new version of this lib code) should fix that.

### How to review

Do code changes make sense ?

### Who can review

Anyone
