### PR TITLE
internal requests now use the incoming host to build links, tests added

### DIFF
--- a/links/links.go
+++ b/links/links.go
@@ -12,9 +12,12 @@ type Builder struct {
 	URL *url.URL
 }
 
-func FromHeadersOrDefault(h *http.Header, defaultURL *url.URL) *Builder {
+func FromHeadersOrDefault(h *http.Header, r *http.Request, defaultURL *url.URL) *Builder {
 	host := h.Get("X-Forwarded-Host")
 	if host == "" {
+		if r.Host != "" {
+			defaultURL.Host = r.Host
+		}
 		return &Builder{
 			URL: defaultURL,
 		}


### PR DESCRIPTION
### What

Added logic so that internal request links will be built with the same host as the request
required by ticket https://jira.ons.gov.uk/browse/DIS-1615

### How to review

Check changes make sense
CI passes
Changes can be tested within dataset-catalogue stack by replacing dp-net with a local version

### Who can review

Anyone
