### PR TITLE
builder uses path-prefix when available, tests fixed

### DIFF
--- a/links/links.go
+++ b/links/links.go
@@ -13,11 +13,14 @@ type Builder struct {
 }
 
 func FromHeadersOrDefault(h *http.Header, r *http.Request, defaultURL *url.URL) *Builder {
+	path := h.Get("X-Forwarded-Path-Prefix")
+
 	host := h.Get("X-Forwarded-Host")
 	if host == "" {
 		if r.Host != "" {
 			defaultURL.Host = r.Host
 		}
+		defaultURL = defaultURL.JoinPath(path)
 		return &Builder{
 			URL: defaultURL,
 		}
@@ -25,15 +28,13 @@ func FromHeadersOrDefault(h *http.Header, r *http.Request, defaultURL *url.URL) 
 
 	scheme := h.Get("X-Forwarded-Proto")
 	if scheme == "" {
-		scheme = "http"
+		scheme = "https"
 	}
 
 	port := h.Get("X-Forwarded-Port")
 	if port != "" {
 		host += ":" + port
 	}
-
-	path := h.Get("X-Forwarded-Path-Prefix")
 
 	url := &url.URL{
 		Scheme: scheme,

--- a/links/links_test.go
+++ b/links/links_test.go
@@ -53,7 +53,7 @@ func Test_FromHeadersOrDefault_With_Forwarded_Headers(t *testing.T) {
 				"forwardedhost",
 				"",
 				"",
-				"http://forwardedhost/",
+				"https://forwardedhost/",
 			},
 			// With only forwarded port
 			{
@@ -71,7 +71,7 @@ func Test_FromHeadersOrDefault_With_Forwarded_Headers(t *testing.T) {
 				"",
 				"",
 				"/prefix",
-				"http://localhost:8080/",
+				"http://localhost:8080/prefix",
 			},
 			// Without all headers except forwarded proto
 			{
@@ -80,7 +80,7 @@ func Test_FromHeadersOrDefault_With_Forwarded_Headers(t *testing.T) {
 				"forwardedhost",
 				"9090",
 				"/prefix",
-				"http://forwardedhost:9090/prefix",
+				"https://forwardedhost:9090/prefix",
 			},
 			// Without all headers except forwarded host
 			{
@@ -89,7 +89,7 @@ func Test_FromHeadersOrDefault_With_Forwarded_Headers(t *testing.T) {
 				"",
 				"9090",
 				"/prefix",
-				"http://localhost:8080/",
+				"http://localhost:8080/prefix",
 			},
 			// Without all headers except forwarded port
 			{
@@ -125,7 +125,7 @@ func Test_FromHeadersOrDefault_With_Forwarded_Headers(t *testing.T) {
 				"forwardedhost",
 				"9090",
 				"",
-				"http://forwardedhost:9090/",
+				"https://forwardedhost:9090/",
 			},
 			// With only forwarded prefix and host
 			{
@@ -134,7 +134,7 @@ func Test_FromHeadersOrDefault_With_Forwarded_Headers(t *testing.T) {
 				"forwardedhost",
 				"",
 				"/prefix",
-				"http://forwardedhost/prefix",
+				"https://forwardedhost/prefix",
 			},
 			// With only forwarded proto and port
 			{
@@ -152,7 +152,7 @@ func Test_FromHeadersOrDefault_With_Forwarded_Headers(t *testing.T) {
 				"",
 				"",
 				"/prefix",
-				"http://localhost:8080/",
+				"http://localhost:8080/prefix",
 			},
 			// With only forwarded port and prefix
 			{
@@ -161,7 +161,7 @@ func Test_FromHeadersOrDefault_With_Forwarded_Headers(t *testing.T) {
 				"",
 				"9090",
 				"/prefix",
-				"http://localhost:8080/",
+				"http://localhost:8080/prefix",
 			},
 		}
 


### PR DESCRIPTION
### What

Path-prefix is also included within internal links if present

### How to review

check changes are ok
CI passes

### Who can review

Anyone
