### PR TITLE
updated builder to better handle internal and external links

### DIFF
--- a/links/links_test.go
+++ b/links/links_test.go
@@ -8,14 +8,13 @@ import (
 	. "github.com/smartystreets/goconvey/convey"
 )
 
-func Test_FromHeadersOrDefault_With_Forwarded_Headers(t *testing.T) {
+func Test_FromHeadersOrDefault(t *testing.T) {
 
 	Convey("Given a list of test cases", t, func() {
 		tests := []struct {
 			defaultURL    string
 			fwdProto      string
 			fwdHost       string
-			fwdPort       string
 			fwdPathPrefix string
 			want          string
 		}{
@@ -25,23 +24,20 @@ func Test_FromHeadersOrDefault_With_Forwarded_Headers(t *testing.T) {
 				"",
 				"",
 				"",
-				"",
 				"http://localhost:8080/",
 			},
 			// With all forwarded headers
 			{
 				"http://localhost:8080/",
 				"https",
-				"forwardedhost",
-				"9090",
+				"api.external.host",
 				"/prefix",
-				"https://forwardedhost:9090/prefix",
+				"https://api.external.host/prefix",
 			},
 			// With only forwarded proto
 			{
 				"http://localhost:8080/",
 				"https",
-				"",
 				"",
 				"",
 				"http://localhost:8080/",
@@ -50,24 +46,13 @@ func Test_FromHeadersOrDefault_With_Forwarded_Headers(t *testing.T) {
 			{
 				"http://localhost:8080/",
 				"",
-				"forwardedhost",
+				"api.external.host",
 				"",
-				"",
-				"https://forwardedhost/",
-			},
-			// With only forwarded port
-			{
-				"http://localhost:8080/",
-				"",
-				"",
-				"9090",
-				"",
-				"http://localhost:8080/",
+				"https://api.external.host/",
 			},
 			// With only forwarded path prefix
 			{
 				"http://localhost:8080/",
-				"",
 				"",
 				"",
 				"/prefix",
@@ -77,91 +62,57 @@ func Test_FromHeadersOrDefault_With_Forwarded_Headers(t *testing.T) {
 			{
 				"http://localhost:8080/",
 				"",
-				"forwardedhost",
-				"9090",
+				"api.external.host",
 				"/prefix",
-				"https://forwardedhost:9090/prefix",
+				"https://api.external.host/prefix",
 			},
 			// Without all headers except forwarded host
 			{
 				"http://localhost:8080/",
 				"https",
 				"",
-				"9090",
 				"/prefix",
 				"http://localhost:8080/prefix",
-			},
-			// Without all headers except forwarded port
-			{
-				"http://localhost:8080/",
-				"https",
-				"forwardedhost",
-				"",
-				"/prefix",
-				"https://forwardedhost/prefix",
 			},
 			// Without all headers except forwarded path prefix
 			{
 				"http://localhost:8080/",
 				"https",
-				"forwardedhost",
-				"9090",
+				"api.external.host",
 				"",
-				"https://forwardedhost:9090/",
+				"https://api.external.host/",
 			},
 			// With only forwarded proto and host
 			{
 				"http://localhost:8080/",
 				"https",
-				"forwardedhost",
+				"api.external.host",
 				"",
-				"",
-				"https://forwardedhost/",
-			},
-			// With only forwarded port and host
-			{
-				"http://localhost:8080/",
-				"",
-				"forwardedhost",
-				"9090",
-				"",
-				"https://forwardedhost:9090/",
+				"https://api.external.host/",
 			},
 			// With only forwarded prefix and host
 			{
 				"http://localhost:8080/",
 				"",
-				"forwardedhost",
-				"",
+				"api.external.host",
 				"/prefix",
-				"https://forwardedhost/prefix",
-			},
-			// With only forwarded proto and port
-			{
-				"http://localhost:8080/",
-				"https",
-				"",
-				"9090",
-				"",
-				"http://localhost:8080/",
+				"https://api.external.host/prefix",
 			},
 			// With only forwarded proto and prefix
 			{
 				"http://localhost:8080/",
 				"https",
 				"",
-				"",
 				"/prefix",
 				"http://localhost:8080/prefix",
 			},
-			// With only forwarded port and prefix
+			// With non-external forwarded host
 			{
 				"http://localhost:8080/",
 				"",
+				"internalhost",
 				"",
-				"9090",
-				"/prefix",
-				"http://localhost:8080/prefix",
+				"http://localhost:8080/",
 			},
 		}
 
@@ -176,16 +127,14 @@ func Test_FromHeadersOrDefault_With_Forwarded_Headers(t *testing.T) {
 			if tt.fwdHost != "" {
 				h.Add("X-Forwarded-Host", tt.fwdHost)
 			}
-			if tt.fwdPort != "" {
-				h.Add("X-Forwarded-Port", tt.fwdPort)
-			}
 			if tt.fwdPathPrefix != "" {
 				h.Add("X-Forwarded-Path-Prefix", tt.fwdPathPrefix)
 			}
 
 			du.JoinPath()
 			r := &http.Request{
-				URL: &url.URL{Scheme: "http", Host: "example.com"},
+				URL:  &url.URL{},
+				Host: "localhost:8080",
 			}
 			builder := FromHeadersOrDefault(&h, r, du)
 			So(builder, ShouldNotBeNil)
@@ -196,64 +145,48 @@ func Test_FromHeadersOrDefault_With_Forwarded_Headers(t *testing.T) {
 
 	})
 
-}
-
-func Test_FromHeadersOrDefault_Without_Forwarded_Headers(t *testing.T) {
-
-	Convey("Given a list of test cases", t, func() {
-		tests := []struct {
-			incomingRequestHost string
-			defaultURL          string
-			want                string
-		}{
-			// Without incoming request host
-			{
-				"",
-				"http://localhost:8080/",
-				"http://localhost:8080/",
-			},
-			// With incoming request host and no port
-			{
-				"localhost",
-				"http://localhost:8080/",
-				"http://localhost/",
-			},
-			// With incoming request host and different port
-			{
-				"localhost:6789",
-				"http://localhost:8080/",
-				"http://localhost:6789/",
-			},
-			{
-				"10.30.100.123:4567",
-				"http://localhost:8080/",
-				"http://10.30.100.123:4567/",
-			},
-			// With incoming request host and default URL with path
-			{
-				"localhost",
-				"http://localhost:8080/some/path",
-				"http://localhost/some/path",
-			},
+	Convey("Given an empty incoming request host", t, func() {
+		r := &http.Request{
+			URL:  &url.URL{},
+			Host: "",
 		}
 
-		for _, tt := range tests {
-			du, err := url.Parse(tt.defaultURL)
+		Convey("When the builder is created with forwarded headers", func() {
+			h := &http.Header{}
+			h.Add("X-Forwarded-Proto", "https")
+			h.Add("X-Forwarded-Host", "api.newhost")
+			h.Add("X-Forwarded-Path-Prefix", "v1")
+
+			defaultURL, err := url.Parse("http://localhost:8080/")
 			So(err, ShouldBeNil)
 
-			incomingRequest := &http.Request{
-				Host: tt.incomingRequestHost,
-				URL:  &url.URL{Scheme: "http", Host: "example.com"},
-			}
+			builder := FromHeadersOrDefault(h, r, defaultURL)
 
-			builder := FromHeadersOrDefault(&http.Header{}, incomingRequest, du)
 			So(builder, ShouldNotBeNil)
 			So(builder.URL, ShouldNotBeNil)
-			So(builder.URL.String(), ShouldEqual, tt.want)
 
-		}
+			Convey("Then the builder URL should be the default URL with the path prefix", func() {
+				So(builder.URL.String(), ShouldEqual, "http://localhost:8080/v1")
+			})
+		})
 
+		Convey("When the builder is created without forwarded headers", func() {
+			h := &http.Header{}
+
+			defaultURL, err := url.Parse("http://localhost:8080/")
+			So(err, ShouldBeNil)
+
+			builder := FromHeadersOrDefault(h, r, defaultURL)
+
+			So(builder, ShouldNotBeNil)
+			So(builder.URL, ShouldNotBeNil)
+
+			Convey("Then the builder URL should be the default URL", func() {
+				So(builder.URL.String(), ShouldEqual, "http://localhost:8080/")
+			})
+		})
 	})
+
 }
 
 func TestBuilder_BuildLink(t *testing.T) {
@@ -349,7 +282,7 @@ func TestBuilder_BuildLink(t *testing.T) {
 	})
 
 	Convey("When an invalid old URL is provided", t, func() {
-		builder := &Builder{URL: &url.URL{Scheme: "http", Host: "localhost:8080"}}
+		builder := &Builder{URL: &url.URL{}}
 		invalidURL := ":invalid/url"
 		newurl, err := builder.BuildLink(invalidURL)
 		So(err, ShouldNotBeNil)


### PR DESCRIPTION
### What

External links are now found by checking for the `api` prefix for the host. Using incoming request host to build internal links

### How to review

Check changes are ok
ci passes
All unit tests make sense, no missing cases

### Who can review

Anyone
