### PR TITLE
rewrite download links using default external url

### DIFF
--- a/links/links.go
+++ b/links/links.go
@@ -51,36 +51,20 @@ func (b *Builder) BuildLink(link string) (string, error) {
 	return b.BuildURL(oldURL).String(), nil
 }
 
-func FromHeadersOrDefaultDownload(h *http.Header, defaultInternalURL, defaultExternalURL *url.URL) *Builder {
-	host := h.Get("X-Forwarded-Host")
-
-	if strings.HasPrefix(host, "api.") {
-		return &Builder{
-			URL: defaultExternalURL.JoinPath("/downloads"),
-		}
-	}
-
-	return &Builder{
-		URL: defaultInternalURL.JoinPath("/downloads"),
-	}
-}
-
-func (b *Builder) BuildDownloadURL(oldURL *url.URL) *url.URL {
-	newPath := oldURL.Path
-	for strings.HasPrefix(newPath, "/downloads") {
-		newPath = strings.TrimPrefix(newPath, "/downloads")
-	}
-
-	apiURL := b.URL.JoinPath(newPath)
-	apiURL.RawQuery = oldURL.RawQuery
-	return apiURL
-}
-
-func (b *Builder) BuildDownloadLink(link string) (string, error) {
+func BuildDownloadLink(link string, defaultURL *url.URL) (string, error) {
 	oldURL, err := url.Parse(link)
 	if err != nil {
 		return "", errors.Wrap(err, "unable to parse link to URL")
 	}
 
-	return b.BuildDownloadURL(oldURL).String(), nil
+	newPath := oldURL.Path
+	for strings.HasPrefix(newPath, "/downloads") {
+		newPath = strings.TrimPrefix(newPath, "/downloads")
+	}
+	newPath = "/downloads" + newPath
+
+	apiURL := defaultURL.JoinPath(newPath)
+	apiURL.RawQuery = oldURL.RawQuery
+
+	return apiURL.String(), nil
 }

--- a/links/links_test.go
+++ b/links/links_test.go
@@ -9,9 +9,8 @@ import (
 )
 
 var (
-	defaultInternalURL         = url.URL{Scheme: "http", Host: "localhost:8080"}
-	defaultInternalDownloadURL = url.URL{Scheme: "http", Host: "localhost:23600"}
-	defaultExternalDownloadURL = url.URL{Scheme: "https", Host: "download.api.host"}
+	defaultInternalURL = &url.URL{Scheme: "http", Host: "localhost:8080"}
+	defaultDownloadURL = &url.URL{Scheme: "https", Host: "download.api.host"}
 )
 
 func Test_FromHeadersOrDefault(t *testing.T) {
@@ -69,7 +68,7 @@ func Test_FromHeadersOrDefault(t *testing.T) {
 				h.Add("X-Forwarded-Path-Prefix", tt.fwdPathPrefix)
 			}
 
-			builder := FromHeadersOrDefault(&h, &defaultInternalURL)
+			builder := FromHeadersOrDefault(&h, defaultInternalURL)
 			So(builder, ShouldNotBeNil)
 			So(builder.URL.String(), ShouldEqual, tt.want)
 		}
@@ -181,142 +180,70 @@ func Test_BuildLink(t *testing.T) {
 	})
 }
 
-func Test_FromHeadersOrDefaultDownload(t *testing.T) {
-	Convey("Given a list of test cases", t, func() {
-		tests := []struct {
-			fwdHost string
-			want    string
-		}{
-			// Without a forwarded host
-			{
-				"",
-				"http://localhost:23600/downloads",
-			},
-			// With an external forwarded host
-			{
-				"api.external.host",
-				"https://download.api.host/downloads",
-			},
-			// With an internal forwarded host
-			{
-				"internalhost",
-				"http://localhost:23600/downloads",
-			},
-		}
-
-		for _, tt := range tests {
-			h := http.Header{}
-
-			if tt.fwdHost != "" {
-				h.Add("X-Forwarded-Host", tt.fwdHost)
-			}
-
-			builder := FromHeadersOrDefaultDownload(&h, &defaultInternalDownloadURL, &defaultExternalDownloadURL)
-			So(builder, ShouldNotBeNil)
-			So(builder.URL.String(), ShouldEqual, tt.want)
-		}
-	})
-}
-
 func Test_BuildDownloadLink(t *testing.T) {
 	Convey("Given a list of test cases", t, func() {
 		tests := []struct {
-			builderURL string
-			oldLink    string
-			want       string
+			oldLink string
+			want    string
 		}{
 			// Empty old link
 			{
-				"http://localhost:23600/downloads",
 				"",
-				"http://localhost:23600/downloads",
+				"https://download.api.host/downloads",
+			},
+			// Old link with only /downloads
+			{
+				"https://download.api.host/downloads",
+				"https://download.api.host/downloads",
+			},
+			// Old link with /downloads and path
+			{
+				"https://download.api.host/downloads/some/path",
+				"https://download.api.host/downloads/some/path",
 			},
 			// Old link with no path
 			{
-				"http://localhost:23600/downloads",
 				"http://localhost:23600",
-				"http://localhost:23600/downloads",
+				"https://download.api.host/downloads",
 			},
 			// Old link with different base url
 			{
-				"http://localhost:23600/downloads",
-				"https://oldHost:1000",
-				"http://localhost:23600/downloads",
+				"https://localhost:23600",
+				"https://download.api.host/downloads",
 			},
 			// Old link with path
 			{
-				"http://localhost:23600/downloads",
 				"http://localhost:23600/some/path",
-				"http://localhost:23600/downloads/some/path",
-			},
-			// Old link with path and different base url
-			{
-				"http://localhost:23600/downloads",
-				"http://oldHost:1000/some/path",
-				"http://localhost:23600/downloads/some/path",
+				"https://download.api.host/downloads/some/path",
 			},
 			// Old link without base url
 			{
-				"http://localhost:23600/downloads",
 				"/some/path",
-				"http://localhost:23600/downloads/some/path",
+				"https://download.api.host/downloads/some/path",
 			},
 			// Old link with query params
 			{
-				"http://localhost:23600/downloads",
 				"http://localhost:23600/some/path?param1=value1&param2=value2",
-				"http://localhost:23600/downloads/some/path?param1=value1&param2=value2",
+				"https://download.api.host/downloads/some/path?param1=value1&param2=value2",
 			},
-			// Old external link to new internal url
+			// Old link with multiple /downloads
 			{
-				"http://localhost:23600/downloads",
-				"https://download.api.host/downloads/some/path",
-				"http://localhost:23600/downloads/some/path",
-			},
-			// Old external link to new external url
-			{
-				"https://download.api.host/downloads",
-				"https://download.api.host/downloads/some/path",
-				"https://download.api.host/downloads/some/path",
-			},
-			// Old external link to new external url (multiple /downloads)
-			{
-				"https://download.api.host/downloads",
 				"https://download.api.host/downloads/downloads/downloads/some/path",
 				"https://download.api.host/downloads/some/path",
-			},
-			// Old internal link to new external url
-			{
-				"https://download.api.host/downloads",
-				"http://localhost:23600/downloads/some/path",
-				"https://download.api.host/downloads/some/path",
-			},
-			// Old internal link to new external url with query params
-			{
-				"https://download.api.host/downloads",
-				"http://localhost:23600/downloads/some/path?param1=value1&param2=value2",
-				"https://download.api.host/downloads/some/path?param1=value1&param2=value2",
 			},
 		}
 
 		for _, tt := range tests {
-			bu, err := url.Parse(tt.builderURL)
-			So(err, ShouldBeNil)
-			builder := &Builder{URL: bu}
 
-			newurl, err := builder.BuildDownloadLink(tt.oldLink)
+			newurl, err := BuildDownloadLink(tt.oldLink, defaultDownloadURL)
 			So(err, ShouldBeNil)
 			So(newurl, ShouldEqual, tt.want)
-
-			// Check that the function hasn't modified the builder's internal URL
-			So(builder.URL.String(), ShouldEqual, tt.builderURL)
 		}
 	})
 
 	Convey("When an invalid old URL is provided", t, func() {
-		builder := &Builder{URL: &url.URL{}}
 		invalidURL := ":invalid/url"
-		newurl, err := builder.BuildDownloadLink(invalidURL)
+		newurl, err := BuildDownloadLink(invalidURL, defaultDownloadURL)
 		So(err, ShouldNotBeNil)
 		So(err.Error(), ShouldContainSubstring, "unable to parse link to URL")
 		So(newurl, ShouldBeEmpty)


### PR DESCRIPTION
### What

Download links are now built from the defaultURL provided. This means all download links will be external and there is no need for the builder to be created for downloads.

### How to review

Check changes are ok
All unit test cases have been checked

### Who can review

Anyone
