### PR TITLE
Remote request host setting from reverse proxy

### DIFF
--- a/handlers/reverseproxy/reverseproxy.go
+++ b/handlers/reverseproxy/reverseproxy.go
@@ -24,7 +24,6 @@ func Create(proxyURL *url.URL, directorFunc func(*http.Request), modifyResponseF
 	}
 	proxy.Director = func(req *http.Request) {
 		director(req)
-		req.Host = proxyURL.Host
 		if directorFunc != nil {
 			directorFunc(req)
 		}


### PR DESCRIPTION
### What

Removed setting request host - this is down to existing problems communicating between services on different hosts. 

I have found by developing a new feature that redirecting up through Florence doesn't work as it redirects the router host not the Florence host.

I looked at the differences between the reverse proxies and this is what I found. Nothing other than Florence and the auth-stub (which mimics Florence) uses this function. 

### How to review

Pull this branch
Do a replace statement in Florence go.mod to the dp-net directory.
Add a volume mapping in Florence's manifest file to the dp-net directory. For example:

```yml
      - ${DP_REPO_DIR:-../../../..}/dp-net:/Users/lindenmckenzie/git/dp-net
```
Start the stack
Try and access localhost:8081/aes - you'll see it now redirects to localhost rather than `dp-frontend-router:20000`

Have a good think about if this is the right way to leverage though. Looks through different places it's used and see if you can ascertain *why* this was here in the first place. 

### Who can review

Not me. 