### PR TITLE
reduce duplicate code and handle forward slash prefix

### DIFF
--- a/links/links.go
+++ b/links/links.go
@@ -33,9 +33,7 @@ func FromHeadersOrDefault(h *http.Header, defaultURL *url.URL) *Builder {
 
 func (b *Builder) BuildURL(oldURL *url.URL) *url.URL {
 	newPath := oldURL.Path
-	for strings.HasPrefix(newPath, "/v1") {
-		newPath = strings.TrimPrefix(newPath, "/v1")
-	}
+	newPath = RemovePrefixFromPath(newPath, "/v1")
 
 	apiURL := b.URL.JoinPath(newPath)
 	apiURL.RawQuery = oldURL.RawQuery
@@ -58,12 +56,9 @@ func BuildDownloadLink(link string, defaultURL *url.URL) (string, error) {
 	}
 
 	newPath := oldURL.Path
-	for strings.HasPrefix(newPath, "/downloads") {
-		newPath = strings.TrimPrefix(newPath, "/downloads")
-	}
-	newPath = "/downloads" + newPath
+	newPath = RemovePrefixFromPath(newPath, "/downloads")
 
-	apiURL := defaultURL.JoinPath(newPath)
+	apiURL := defaultURL.JoinPath("downloads", newPath)
 	apiURL.RawQuery = oldURL.RawQuery
 
 	return apiURL.String(), nil
@@ -76,13 +71,17 @@ func BuildDownloadNewLink(link string, defaultURL *url.URL) (string, error) {
 	}
 
 	newPath := oldURL.Path
-	for strings.HasPrefix(newPath, "/downloads-new") {
-		newPath = strings.TrimPrefix(newPath, "/downloads-new")
-	}
-	newPath = "/downloads-new" + newPath
+	newPath = RemovePrefixFromPath(newPath, "/downloads-new")
 
-	apiURL := defaultURL.JoinPath(newPath)
+	apiURL := defaultURL.JoinPath("downloads-new", newPath)
 	apiURL.RawQuery = oldURL.RawQuery
 
 	return apiURL.String(), nil
+}
+
+func RemovePrefixFromPath(path, prefix string) string {
+	for strings.HasPrefix(path, prefix) {
+		path = strings.TrimPrefix(path, prefix)
+	}
+	return path
 }

--- a/links/links_test.go
+++ b/links/links_test.go
@@ -221,6 +221,11 @@ func Test_BuildDownloadLink(t *testing.T) {
 				"/some/path",
 				"https://download.api.host/downloads/some/path",
 			},
+			// Old link without base url and / prefix
+			{
+				"some/path",
+				"https://download.api.host/downloads/some/path",
+			},
 			// Old link with query params
 			{
 				"http://localhost:23600/some/path?param1=value1&param2=value2",
@@ -234,7 +239,6 @@ func Test_BuildDownloadLink(t *testing.T) {
 		}
 
 		for _, tt := range tests {
-
 			newurl, err := BuildDownloadLink(tt.oldLink, defaultDownloadURL)
 			So(err, ShouldBeNil)
 			So(newurl, ShouldEqual, tt.want)
@@ -291,6 +295,11 @@ func Test_BuildDownloadNewLink(t *testing.T) {
 				"/some/path",
 				"https://download.api.host/downloads-new/some/path",
 			},
+			// Old link without base url and / prefix
+			{
+				"some/path",
+				"https://download.api.host/downloads-new/some/path",
+			},
 			// Old link with query params
 			{
 				"http://localhost:23600/some/path?param1=value1&param2=value2",
@@ -304,7 +313,6 @@ func Test_BuildDownloadNewLink(t *testing.T) {
 		}
 
 		for _, tt := range tests {
-
 			newurl, err := BuildDownloadNewLink(tt.oldLink, defaultDownloadURL)
 			So(err, ShouldBeNil)
 			So(newurl, ShouldEqual, tt.want)
@@ -317,5 +325,27 @@ func Test_BuildDownloadNewLink(t *testing.T) {
 		So(err, ShouldNotBeNil)
 		So(err.Error(), ShouldContainSubstring, "unable to parse link to URL")
 		So(newurl, ShouldBeEmpty)
+	})
+}
+
+func Test_RemovePrefixFromPath(t *testing.T) {
+	Convey("RemovePrefixFromPath removes all leading prefix instances from the path", t, func() {
+		tests := []struct {
+			path   string
+			prefix string
+			want   string
+		}{
+			{"", "/prefix", ""},
+			{"/prefix", "/prefix", ""},
+			{"/prefix/some/path", "/prefix", "/some/path"},
+			{"/prefix/prefix/prefix/some/path", "/prefix", "/some/path"},
+			{"/some/path", "/prefix", "/some/path"},
+			{"some/path", "/prefix", "some/path"},
+		}
+
+		for _, tt := range tests {
+			result := RemovePrefixFromPath(tt.path, tt.prefix)
+			So(result, ShouldEqual, tt.want)
+		}
 	})
 }


### PR DESCRIPTION
### What

- Part of work required for https://officefornationalstatistics.atlassian.net/browse/DIS-3582
- Download links can be rewritten with or without the `/` prefix. (I have tested locally with the dataset-api)
- New function to remove specified prefix from path to simplify code

### How to review

- Check changes are ok

### Who can review

Anyone
