### PR TITLE
replace /downloads-new with downloads/files

### DIFF
--- a/links/links.go
+++ b/links/links.go
@@ -64,16 +64,16 @@ func BuildDownloadLink(link string, defaultURL *url.URL) (string, error) {
 	return apiURL.String(), nil
 }
 
-func BuildDownloadNewLink(link string, defaultURL *url.URL) (string, error) {
+func BuildDownloadFilesLink(link string, defaultURL *url.URL) (string, error) {
 	oldURL, err := url.Parse(link)
 	if err != nil {
 		return "", errors.Wrap(err, "unable to parse link to URL")
 	}
 
 	newPath := oldURL.Path
-	newPath = RemovePrefixFromPath(newPath, "/downloads-new")
+	newPath = RemovePrefixFromPath(newPath, "/downloads/files")
 
-	apiURL := defaultURL.JoinPath("downloads-new", newPath)
+	apiURL := defaultURL.JoinPath("downloads/files", newPath)
 	apiURL.RawQuery = oldURL.RawQuery
 
 	return apiURL.String(), nil

--- a/links/links_test.go
+++ b/links/links_test.go
@@ -256,7 +256,7 @@ func Test_BuildDownloadLink(t *testing.T) {
 	})
 }
 
-func Test_BuildDownloadNewLink(t *testing.T) {
+func Test_BuildDownloadFilesLink(t *testing.T) {
 	Convey("Given a list of test cases", t, func() {
 		tests := []struct {
 			oldLink string
@@ -265,64 +265,65 @@ func Test_BuildDownloadNewLink(t *testing.T) {
 			// Empty old link
 			{
 				"",
-				"https://download.api.host/downloads-new",
+				"https://download.api.host/downloads/files",
 			},
-			// Old link with only /downloads-new
+			// Old link with only /downloads-files
 			{
-				"https://download.api.host/downloads-new",
-				"https://download.api.host/downloads-new",
+				"https://download.api.host/downloads/files",
+				"https://download.api.host/downloads/files",
 			},
-			// Old link with /downloads-new and path
+			// Old link with /downloads-files and path
 			{
-				"https://download.api.host/downloads-new/some/path",
-				"https://download.api.host/downloads-new/some/path",
+				"https://download.api.host/downloads/files/some/path",
+				"https://download.api.host/downloads/files/some/path",
 			},
 			// Old link with no path
 			{
 				"http://localhost:23600",
-				"https://download.api.host/downloads-new",
+				"https://download.api.host/downloads/files",
 			},
 			// Old link with different base url
 			{
 				"https://localhost:23600",
-				"https://download.api.host/downloads-new",
+				"https://download.api.host/downloads/files",
 			},
 			// Old link with path
 			{
 				"http://localhost:23600/some/path",
-				"https://download.api.host/downloads-new/some/path",
+				"https://download.api.host/downloads/files/some/path",
 			},
 			// Old link without base url
 			{
 				"/some/path",
-				"https://download.api.host/downloads-new/some/path",
+				"https://download.api.host/downloads/files/some/path",
 			},
 			// Old link without base url and / prefix
 			{
 				"some/path",
-				"https://download.api.host/downloads-new/some/path",
+				"https://download.api.host/downloads/files/some/path",
 			},
 			// Old link with query params
 			{
 				"http://localhost:23600/some/path?param1=value1&param2=value2",
-				"https://download.api.host/downloads-new/some/path?param1=value1&param2=value2",
+				"https://download.api.host/downloads/files/some/path?param1=value1&param2=value2",
 			},
-			// Old link with multiple /downloads-new
+			// Old link with multiple /downloads-files
 			{
-				"https://download.api.host/downloads-new/downloads-new/downloads-new/some/path",
-				"https://download.api.host/downloads-new/some/path",
+				"https://download.api.host/downloads/files/downloads/files/downloads/files/some/path",
+				"https://download.api.host/downloads/files/some/path",
 			},
 		}
 
 		for _, tt := range tests {
-			newurl, err := BuildDownloadNewLink(tt.oldLink, defaultDownloadURL)
+			newurl, err := BuildDownloadFilesLink(tt.oldLink, defaultDownloadURL)
 			So(err, ShouldBeNil)
 			So(newurl, ShouldEqual, tt.want)
 		}
 	})
 
 	Convey("When an invalid old URL is provided", t, func() {
-		newurl, err := BuildDownloadNewLink(invalidURL, defaultDownloadURL)
+		invalidURL := ":invalid/url"
+		newurl, err := BuildDownloadFilesLink(invalidURL, defaultDownloadURL)
 		So(err, ShouldNotBeNil)
 		So(err.Error(), ShouldContainSubstring, "unable to parse link to URL")
 		So(newurl, ShouldBeEmpty)


### PR DESCRIPTION
### What

- Remove rewriting for `downloads-new` and replace with `downloads/files` as this is now standard
- https://github.com/search?q=org%3AONSdigital%20BuildDownloadNewLink&type=code - As we can see in this Github search, the only place `BuildDownloadNewLink` was being called was in the `dataset-api` which is now being changed to write links as `/downloads/files`
- https://officefornationalstatistics.atlassian.net/browse/DIS-4221 - Ticket which requires the changes from this PR

### How to review

- Check changes are ok
- No local testing as of now (only unit tests)

### Who can review

- Anyone
