### PR TITLE
Updated NewServer function to allow an optional parameter to set time…

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,10 +95,11 @@ This Server is intended to be used by all ONS digital publishing services that r
 
 #### Creation
 
-You have 2 options available (depending on if you want to specify a request and write timeout)
+To create the Server, it can be instantiated via the following function:
 
 - NewServer(bindAddr string, router http.Handler)
-- NewServerWithTimeout(bindAddr string, router http.Handler, requestTimeout time.Duration, writeTimeout time.Duration, timeoutMessage string)
+
+If custom timeout values are required, then an optional TimeoutConfiguration parameter can be added to specify the timeout values.
 
 Assuming you have created a router with your API handlers, you can create the http server like so:
 

--- a/README.md
+++ b/README.md
@@ -95,11 +95,10 @@ This Server is intended to be used by all ONS digital publishing services that r
 
 #### Creation
 
-To create the Server, it can be instantiated via the following function:
+You have 2 options available (depending on if you want to specify custom timeout values)
 
 - NewServer(bindAddr string, router http.Handler)
-
-If custom timeout values are required, then an optional TimeoutConfiguration parameter can be added to specify the timeout values.
+- NewServerWithCustomTimeouts(bindAddr string, router http.Handler, timeoutConfig TimeoutConfig)
 
 Assuming you have created a router with your API handlers, you can create the http server like so:
 

--- a/http/server.go
+++ b/http/server.go
@@ -44,31 +44,17 @@ type Server struct {
 }
 
 // NewServer creates a new server
-func NewServer(bindAddr string, router http.Handler, opts ...TimeoutConfig) *Server {
+func NewServer(bindAddr string, router http.Handler) *Server {
 	middleware := map[string]alice.Constructor{
 		RequestIDHandlerKey: request.HandlerRequestID(16),
 		LogHandlerKey:       log.Middleware,
 	}
 
-	server := Server{}
-	server.Alice = nil
-	server.middleware = middleware
-	server.middlewareOrder = []string{RequestIDHandlerKey, LogHandlerKey}
-	server.HandleOSSignals = true
-	server.DefaultShutdownTimeout = 10 * time.Second
-
-	if opts != nil {
-		server.Server = http.Server{
-			Handler:           router,
-			Addr:              bindAddr,
-			ReadTimeout:       opts[0].ReadTimeout,
-			WriteTimeout:      opts[0].WriteTimeout,
-			ReadHeaderTimeout: opts[0].ReadHeaderTimeout,
-			IdleTimeout:       opts[0].IdleTimeout,
-			MaxHeaderBytes:    0,
-		}
-	} else {
-		server.Server = http.Server{
+	return &Server{
+		Alice:           nil,
+		middleware:      middleware,
+		middlewareOrder: []string{RequestIDHandlerKey, LogHandlerKey},
+		Server: http.Server{
 			Handler:           router,
 			Addr:              bindAddr,
 			ReadTimeout:       5 * time.Second,
@@ -76,10 +62,34 @@ func NewServer(bindAddr string, router http.Handler, opts ...TimeoutConfig) *Ser
 			ReadHeaderTimeout: 0,
 			IdleTimeout:       0,
 			MaxHeaderBytes:    0,
-		}
+		},
+		HandleOSSignals:        true,
+		DefaultShutdownTimeout: 10 * time.Second,
+	}
+}
+
+func NewServerWithCustomTimeouts(bindAddr string, router http.Handler, timeoutConfig TimeoutConfig) *Server {
+	middleware := map[string]alice.Constructor{
+		RequestIDHandlerKey: request.HandlerRequestID(16),
+		LogHandlerKey:       log.Middleware,
 	}
 
-	return &server
+	return &Server{
+		Alice:           nil,
+		middleware:      middleware,
+		middlewareOrder: []string{RequestIDHandlerKey, LogHandlerKey},
+		Server: http.Server{
+			Handler:           router,
+			Addr:              bindAddr,
+			ReadTimeout:       timeoutConfig.ReadTimeout,
+			WriteTimeout:      timeoutConfig.WriteTimeout,
+			ReadHeaderTimeout: timeoutConfig.ReadHeaderTimeout,
+			IdleTimeout:       timeoutConfig.IdleTimeout,
+			MaxHeaderBytes:    0,
+		},
+		HandleOSSignals:        true,
+		DefaultShutdownTimeout: 10 * time.Second,
+	}
 }
 
 func (s *Server) prep() {

--- a/http/server.go
+++ b/http/server.go
@@ -20,6 +20,13 @@ const (
 	ResponseWriteGrace  time.Duration = 100 * time.Millisecond
 )
 
+type TimeoutConfig struct {
+	WriteTimeout      time.Duration
+	ReadTimeout       time.Duration
+	ReadHeaderTimeout time.Duration
+	IdleTimeout       time.Duration
+}
+
 // Server is a http.Server with sensible defaults, which supports
 // configurable middleware and timeouts, and shuts down cleanly
 // on SIGINT/SIGTERM
@@ -37,17 +44,31 @@ type Server struct {
 }
 
 // NewServer creates a new server
-func NewServer(bindAddr string, router http.Handler) *Server {
+func NewServer(bindAddr string, router http.Handler, opts ...TimeoutConfig) *Server {
 	middleware := map[string]alice.Constructor{
 		RequestIDHandlerKey: request.HandlerRequestID(16),
 		LogHandlerKey:       log.Middleware,
 	}
 
-	return &Server{
-		Alice:           nil,
-		middleware:      middleware,
-		middlewareOrder: []string{RequestIDHandlerKey, LogHandlerKey},
-		Server: http.Server{
+	server := Server{}
+	server.Alice = nil
+	server.middleware = middleware
+	server.middlewareOrder = []string{RequestIDHandlerKey, LogHandlerKey}
+	server.HandleOSSignals = true
+	server.DefaultShutdownTimeout = 10 * time.Second
+
+	if opts != nil {
+		server.Server = http.Server{
+			Handler:           router,
+			Addr:              bindAddr,
+			ReadTimeout:       opts[0].ReadTimeout,
+			WriteTimeout:      opts[0].WriteTimeout,
+			ReadHeaderTimeout: opts[0].ReadHeaderTimeout,
+			IdleTimeout:       opts[0].IdleTimeout,
+			MaxHeaderBytes:    0,
+		}
+	} else {
+		server.Server = http.Server{
 			Handler:           router,
 			Addr:              bindAddr,
 			ReadTimeout:       5 * time.Second,
@@ -55,20 +76,10 @@ func NewServer(bindAddr string, router http.Handler) *Server {
 			ReadHeaderTimeout: 0,
 			IdleTimeout:       0,
 			MaxHeaderBytes:    0,
-		},
-		HandleOSSignals:        true,
-		DefaultShutdownTimeout: 10 * time.Second,
+		}
 	}
-}
 
-// NewServerWithTimeout creates a new server with request timeout duration
-// and a message that will be in the response body
-func NewServerWithTimeout(bindAddr string, router http.Handler, requestTimeout, writeTimeout time.Duration, timeoutMessage string) *Server {
-	server := NewServer(bindAddr, router)
-	server.RequestTimeout = requestTimeout
-	server.WriteTimeout = writeTimeout
-	server.TimeoutMessage = timeoutMessage
-	return server
+	return &server
 }
 
 func (s *Server) prep() {

--- a/http/server_test.go
+++ b/http/server_test.go
@@ -342,12 +342,8 @@ func TestGetFreePort(t *testing.T) {
 }
 
 func startServer(address string, handler http.Handler, writeTimeout, requestTimeout time.Duration) (errorChan chan error, shutdownFunc func()) {
-	var s *Server
-	if requestTimeout > 0 && writeTimeout > 0 {
-		s = NewServerWithTimeout(address, handler, requestTimeout, writeTimeout, "test server timeout")
-	} else {
-		s = NewServer(address, handler)
-	}
+	s := NewServer(address, handler)
+
 	s.WriteTimeout = writeTimeout
 	s.RequestTimeout = requestTimeout
 	s.HandleOSSignals = false

--- a/http/server_test.go
+++ b/http/server_test.go
@@ -309,13 +309,13 @@ func TestServer_LongRunningOperation(t *testing.T) {
 			Convey("when a request is made to the server", func() {
 				resp, err := http.Get("http://" + a)
 
-				Convey("the request is terminated with a 'test server timeout' response", func() {
+				Convey("the request is terminated with a 'connection timeout' response", func() {
 					So(err, ShouldBeNil)
 					So(resp.StatusCode, ShouldEqual, http.StatusServiceUnavailable)
 
 					b, err := io.ReadAll(resp.Body)
 					So(err, ShouldEqual, nil)
-					So(string(b), ShouldEqual, "test server timeout")
+					So(string(b), ShouldEqual, "connection timeout")
 				})
 			})
 		})

--- a/http/server_test.go
+++ b/http/server_test.go
@@ -84,6 +84,22 @@ func TestNew(t *testing.T) {
 			})
 		})
 
+		Convey("Setting up a server with custom timeouts should set them correctly", func() {
+			timeoutConfig := TimeoutConfig{
+				ReadTimeout:       10 * time.Second,
+				WriteTimeout:      10 * time.Second,
+				IdleTimeout:       0,
+				ReadHeaderTimeout: 0,
+			}
+			s := NewServer(":0", dummyHandler, timeoutConfig)
+
+			So(s, ShouldNotBeNil)
+			So(s.WriteTimeout, ShouldEqual, time.Second*10)
+			So(s.ReadTimeout, ShouldEqual, time.Second*10)
+			So(s.IdleTimeout, ShouldEqual, 0)
+			So(s.ReadHeaderTimeout, ShouldEqual, 0)
+		})
+
 		Convey("prep should prepare the server correctly", func() {
 			Convey("prep should create a valid Server instance", func() {
 				s := NewServer(":0", dummyHandler)

--- a/http/server_test.go
+++ b/http/server_test.go
@@ -91,7 +91,7 @@ func TestNew(t *testing.T) {
 				IdleTimeout:       0,
 				ReadHeaderTimeout: 0,
 			}
-			s := NewServer(":0", dummyHandler, timeoutConfig)
+			s := NewServerWithCustomTimeouts(":0", dummyHandler, timeoutConfig)
 
 			So(s, ShouldNotBeNil)
 			So(s.WriteTimeout, ShouldEqual, time.Second*10)


### PR DESCRIPTION
…outs, removed NewServerWithTimeout as it was not performant.

### What

Following performance testing of the download service it was noticed that the NewServerWithTimeout function had introduced OOMKills while under load.  To address this, an optional parameter has been added to the NewServer function so that all timeout values can be set on initial instantiation rather than overriding the initial values.

Removed the non performant function NewServerWithTimeout as this is not being used anywhere in our services.

### How to review

Ensure the tests pass and the changes make sense.

### Who can review

Anyone.
